### PR TITLE
MVP for zib-ContactInformation implentation that is mapped on two different profiles

### DIFF
--- a/examples/MVPPatient.xml
+++ b/examples/MVPPatient.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patient xmlns="http://hl7.org/fhir">
+    <meta>
+        <profile value="http://nictiz.nl/fhir/Patient-testConctactInformation"/>
+    </meta>
+    <telecom>
+        <system value="email"/>
+        <value value="info@example.com"/>
+        <use value="home"/>
+    </telecom>
+    <telecom>
+        <extension url="http://nictiz.nl/fhir/ext-zib-ContactInformation-TelecomType">
+            <valueCodeableConcept>
+                <coding>
+                    <system value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
+                    <code value="MC"/>
+                </coding>
+            </valueCodeableConcept>
+        </extension>
+        <system value="phone"/>
+        <value value="0031-1234567"/>
+        <use value="home"/>
+    </telecom>
+    <telecom>
+        <system value="other"/>
+        <value value="https://linkedin.com/..."/>
+    </telecom>
+</Patient>

--- a/resources/Patient-testConctactInformation.xml
+++ b/resources/Patient-testConctactInformation.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="http://nictiz.nl/fhir/Patient-testConctactInformation" />
+  <name value="PatientTestConctactInformation" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="cda" />
+    <uri value="http://hl7.org/v3/cda" />
+    <name value="CDA (R2)" />
+  </mapping>
+  <mapping>
+    <identity value="w5" />
+    <uri value="http://hl7.org/fhir/fivews" />
+    <name value="FiveWs Pattern Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="v2" />
+    <uri value="http://hl7.org/v2" />
+    <name value="HL7 v2 Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="loinc" />
+    <uri value="http://loinc.org" />
+    <name value="LOINC code for the element" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Patient" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Patient" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Patient.telecom">
+      <path value="Patient.telecom" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="system" />
+        </discriminator>
+        <discriminator>
+          <type value="value" />
+          <path value="use" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Patient.telecom:telephoneNumbers">
+      <path value="Patient.telecom" />
+      <sliceName value="telephoneNumbers" />
+      <type>
+        <code value="ContactPoint" />
+        <profile value="http://niciz.nl/fhir/zib-ContactPoint-TelephoneNumbers" />
+      </type>
+    </element>
+    <element id="Patient.telecom:e-mailAddresses">
+      <path value="Patient.telecom" />
+      <sliceName value="e-mailAddresses" />
+      <type>
+        <code value="ContactPoint" />
+        <profile value="http://niciz.nl/fhir/zib-ContactPoint-E-mailAddresses" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/ext-zib-ContactInformation-TelecomType.xml
+++ b/resources/ext-zib-ContactInformation-TelecomType.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <url value="http://nictiz.nl/fhir/ext-zib-ContactInformation-TelecomType" />
+  <name value="ExtZibContactInformationTelecomType" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="ContactPoint" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/ext-zib-ContactInformation-TelecomType" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20200901000000" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/terminology/TelecomTypeCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20200901000000.xml
+++ b/resources/terminology/TelecomTypeCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20200901000000.xml
@@ -1,0 +1,72 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20200901000000"/>
+    <meta>
+        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+    </meta>
+    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+        <valuePeriod>
+            <start value="2020-09-01T00:00:00+01:00"/>
+        </valuePeriod>
+    </extension>
+    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1--20200901000000"/>
+    <identifier>
+        <use value="official"/>
+        <system value="http://art-decor.org/ns/oids/vs"/>
+        <value value="2.16.840.1.113883.2.4.3.11.60.40.2.20.6.1"/>
+    </identifier>
+    <version value="2020-09-01T00:00:00"/>
+    <name value="TelecomTypeCodelijst"/>
+    <title value="TelecomTypeCodelijst"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Registratie aan de bron"/>
+    <contact>
+        <name value="Registratie aan de bron"/>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.registratieaandebron.nl"/>
+        </telecom>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.zibs.nl"/>
+        </telecom>
+    </contact>
+    <description value="TelecomTypeCodelijst"/>
+    <immutable value="false"/>
+    <compose>
+        <include>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Mobiel telefoonnummer"/>
+                </extension>
+                <code value="MC"/>
+                <display value="Mobile Phone"/>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Pieper"/>
+                </extension>
+                <code value="PG"/>
+                <display value="Pager"/>
+            </concept>
+        </include>
+        <include>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.22.1"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Vast telefoonnummer"/>
+                </extension>
+                <code value="LL"/>
+                <display value="Land Line"/>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Fax"/>
+                </extension>
+                <code value="FAX"/>
+                <display value="Fax"/>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/terminology/zib-ContactInformation-E-mailAddresses-Uses.xml
+++ b/resources/terminology/zib-ContactInformation-E-mailAddresses-Uses.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="zib-ContactInformation-E-mailAddresses-uses"/>
+    <url value="http://nictiz.nl/fhir/ValueSet/zib-ContactInformation-E-mailAddresses-uses"/>
+    <version value="4.0.1"/>
+    <name value="zibContactInformationEmailAddressesUses"/>
+    <title value="zib ContactInformation E-mailAddress uses"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Nictiz"/>
+    <description value="Telecommunications form for contact point, restricted to the use for the TelephoneNumbers concept of zib ContactInformation."/>
+    <immutable value="true"/>
+    <compose>
+        <include>
+            <system value="http://hl7.org/fhir/contact-point-use"/>
+            <concept>
+                <code value="home"/>
+                <display value="Home"/>
+            </concept>
+            <concept>
+                <code value="work"/>
+                <display value="Work"/>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/terminology/zib-ContactInformation-TelephoneNumbers-Systems.xml
+++ b/resources/terminology/zib-ContactInformation-TelephoneNumbers-Systems.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="zib-ContactInformation-TelephoneNumbers-systems"/>
+    <url value="http://nictiz.nl/fhir/ValueSet/zib-ContactInformation-TelephoneNumbers-systems"/>
+    <version value="4.0.1"/>
+    <name value="zibContactInformationTelephoneNumbersSystems"/>
+    <title value="zib ContactInformation TelephoneNumbers systems"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Nictiz"/>
+    <description value="Telecommunications form for contact point, restricted to the use for the TelephoneNumbers concept of zib ContactInformation."/>
+    <immutable value="true"/>
+    <compose>
+        <include>
+            <system value="http://hl7.org/fhir/contact-point-system"/>
+            <concept>
+                <code value="phone"/>
+                <display value="Phone"/>
+            </concept>
+            <concept>
+                <code value="fax"/>
+                <display value="Fax"/>
+            </concept>
+            <concept>
+                <code value="pager"/>
+                <display value="Pager"/>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/terminology/zib-ContactInformation-TelephoneNumbers-Uses.xml
+++ b/resources/terminology/zib-ContactInformation-TelephoneNumbers-Uses.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="zib-ContactInformation-TelephoneNumbers-uses"/>
+    <url value="http://nictiz.nl/fhir/ValueSet/zib-ContactInformation-TelephoneNumbers-uses"/>
+    <version value="4.0.1"/>
+    <name value="zibContactInformationTelephoneNumbersUses"/>
+    <title value="zib ContactInformation TelephoneNumbers uses"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Nictiz"/>
+    <description value="Telecommunications form for contact point, restricted to the use for the TelephoneNumbers concept of zib ContactInformation."/>
+    <immutable value="true"/>
+    <compose>
+        <include>
+            <system value="http://hl7.org/fhir/contact-point-use"/>
+            <concept>
+                <code value="home"/>
+                <display value="Home"/>
+            </concept>
+            <concept>
+                <code value="work"/>
+                <display value="Work"/>
+            </concept>
+            <concept>
+                <code value="temp"/>
+                <display value="Temp"/>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/zib-ContactPoint-E-mailAdresses.xml
+++ b/resources/zib-ContactPoint-E-mailAdresses.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="zib-ContactPoint-E-mailAddresses" />
+  <url value="http://niciz.nl/fhir/zib-ContactPoint-E-mailAddresses" />
+  <name value="ZibContactPointEmailAddresses" />
+  <title value="zib ContactPoint E-mailAddresses" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="v2" />
+    <uri value="http://hl7.org/v2" />
+    <name value="HL7 v2 Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="servd" />
+    <uri value="http://www.omg.org/spec/ServD/1.0/" />
+    <name value="ServD" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="ContactPoint" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ContactPoint" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="ContactPoint.system">
+      <path value="ContactPoint.system" />
+      <fixedCode value="email" />
+    </element>
+    <element id="ContactPoint.use">
+      <path value="ContactPoint.use" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://nictiz.nl/fhir/ValueSet/zib-ContactInformation-E-mailAddresses-uses" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib-ContactPoint-TelephoneNumbers.xml
+++ b/resources/zib-ContactPoint-TelephoneNumbers.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="zib-ContactPoint-TelephoneNumbers" />
+  <url value="http://niciz.nl/fhir/zib-ContactPoint-TelephoneNumbers" />
+  <name value="ZibContactPointTelephoneNumbers" />
+  <title value="zib ContactPoint TelephoneNumbers" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="v2" />
+    <uri value="http://hl7.org/v2" />
+    <name value="HL7 v2 Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="servd" />
+    <uri value="http://www.omg.org/spec/ServD/1.0/" />
+    <name value="ServD" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <type value="ContactPoint" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ContactPoint" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="ContactPoint.extension">
+      <path value="ContactPoint.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="ContactPoint.extension:telecomTypeCodeLijst">
+      <path value="ContactPoint.extension" />
+      <sliceName value="telecomTypeCodeLijst" />
+      <min value="1" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/ext-zib-ContactInformation-TelecomType" />
+      </type>
+    </element>
+    <element id="ContactPoint.system">
+      <path value="ContactPoint.system" />
+      <short value="phone | fax | pager" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://nictiz.nl/fhir/ValueSet/zib-ContactInformation-TelephoneNumbers-systems" />
+      </binding>
+    </element>
+    <element id="ContactPoint.use">
+      <path value="ContactPoint.use" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://nictiz.nl/fhir/ValueSet/zib-ContactInformation-TelephoneNumbers-uses" />
+      </binding>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
The example MVPPatient shows how this can be used: there are two known slices for the two zib concepts, plus a third unknown slice for other uses. The system/use combination to designate the TelephoneNumber slice can only be used in combination with the extension -- if the extension is removed from the example, validation will fail.