### PR TITLE
release-notes template

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,6 @@
 # Nictiz-R4-Zib2020 Release Notes
 
-This document contains release notes per zib, indicating differences with their [STU3 versions])(https://simplifier.net/packages/nictiz.fhir.nl.stu3.zib2017/), deviations from the [profiling guidelines](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4) and other points of interest.
+This document contains release notes per zib, indicating differences with their [STU3 versions](https://simplifier.net/packages/nictiz.fhir.nl.stu3.zib2017/), deviations from the [profiling guidelines](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4) and other points of interest.
 
 ## [zib-name]
 * [item 1]

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,7 @@
+# Nictiz-R4-Zib2020 Release Notes
+
+This document contains release notes per zib, indicating differences with their [STU3 versions])(https://simplifier.net/packages/nictiz.fhir.nl.stu3.zib2017/), deviations from the [profiling guidelines](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4) and other points of interest.
+
+## [zib-name]
+* [item 1]
+* [item 2]


### PR DESCRIPTION
Differences compared to last 'release' to Validatieraad aren't really accounted for in this template. Maybe add an H3 header per zib (`###`) to indicate this?