### PR TITLE
Cleanup

### DIFF
--- a/known-issues.yml
+++ b/known-issues.yml
@@ -6,23 +6,9 @@ ext-LanguageProficiency.CommunicationDetails:
 
 zib-AddressInformation:
   zib deviations:
-    Address.line.extension:streetName.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    Address.line.extension:houseNumber.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    Address.line.extension:houseNumberLetter-houseNumberAddition.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
     Address.line.extension:houseNumberIndication.value[x]:
       - datatype: string
         reason: The mapping of zib AddressInformation on the FHIR Address datatype is the result of compatibility with HL7v3, which is the format that a lot of healthcare data in the Netherlands is stored in.  As a result of this, the zib HouseNumberIndication concept with CD datatype is mapped to a FHIR string datatype with a constraint added (the value can only be 'by' or 'to').
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    Address.line.extension:additionalInformation.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
 
 zib-ContactInformation-TelephoneNumbers:
   zib deviations:
@@ -117,21 +103,6 @@ zib-HealthProfessional-PractitionerRole:
 
 zib-NameInformation:
   zib deviations:
-    HumanName.extension:humannameAssemblyOrder.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    HumanName.family.extension:prefix.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    HumanName.family.extension:lastName.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    HumanName.family.extension:partnerPrefix.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
-    HumanName.family.extension:partnerLastName.value[x]:
-      - cardinality: 1..1
-        reason: The used extension makes the value required (1..1), but the use of the extension itself is optional (0..1), effectively resulting a cardinality of 0..1 for this element.
     HumanName.prefix:
       - cardinality: 0..*
         reason: prefix and suffix are mapped to the "titles" concept from the zib. There's a mismatch however in the way this information is represented in the zib and in FHIR. The mapping is documented in the profile.
@@ -178,8 +149,6 @@ zib-Patient:
     Patient.contact.extension:contactPerson.value[x]:
       - datatype: Reference
         reason: This is an additional reference to a separate zib-ContactPerson (RelatedPerson) instance, next to the information in Pateint.contact. Patient.contact and RelatedPerson can both be used to capture the information from zib-ContactPerson, but each are used within a different context. Information may therefore be duplicated; this is the recommended way.
-      - cardinality: 1..1
-        reason: The inclusion of the extension itself is optional. However, _when_ it is included, it should contain a value to make sense. 
     Patient.contact.name:
       - datatype: HumanName
         reason: A name in FHIR is represented using the HumanName datatype, not as a separate resource.

--- a/known-issues.yml
+++ b/known-issues.yml
@@ -4,6 +4,18 @@ ext-LanguageProficiency.CommunicationDetails:
       - cardinality: 0..1
         reason: FHIR restricts Extension.value to a max cardinality of 0..1. To use it more than once, the extension should be added 0..* in the hosting element.
 
+pattern-NlCoreHealthProfessionalReference:
+  ignored issues:
+    StructureDefinition:
+      - message: "sd-pg-08: 'The title of the StructureDefinition should conform to the profiling guidelines'"
+        reason: The title is shown in the hosting profiles as the name of the datatype. "zib HealthProfessional Reference" is more descriptive than the title according to the profiling guidelines ("pattern NlCoreHealthProfessionalReference").
+
+pattern-ZibHealthProfessionalReference:
+  ignored issues:
+    StructureDefinition:
+      - message: "sd-pg-08: 'The title of the StructureDefinition should conform to the profiling guidelines'"
+        reason: The title is shown in the hosting profiles as the name of the datatype. "zib HealthProfessional Reference" is more descriptive than the title according to the profiling guidelines ("pattern ZibHealthProfessionalReference").
+
 zib-AddressInformation:
   zib deviations:
     Address.line.extension:houseNumberIndication.value[x]:

--- a/resources/nl-core/pattern-NlCoreHealthProfessionalReference.xml
+++ b/resources/nl-core/pattern-NlCoreHealthProfessionalReference.xml
@@ -3,7 +3,7 @@
   <id value="pattern-NlCoreHealthProfessionalReference" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/pattern-NlCoreHealthProfessionalReference" />
   <name value="PatternNlCoreHealthProfessionalReference" />
-  <title value="Pattern for zib HealthProfessional References" />
+  <title value="zib HealthProfessional Reference" />
   <status value="draft" />
   <publisher value="Nictiz" />
   <contact>

--- a/resources/zib/pattern-ZibHealthProfessionalReference.xml
+++ b/resources/zib/pattern-ZibHealthProfessionalReference.xml
@@ -3,7 +3,7 @@
   <id value="pattern-ZibHealthProfessionalReference" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/pattern-ZibHealthProfessionalReference" />
   <name value="PatternZibHealthProfessionalReference" />
-  <title value="Pattern for zib HealthProfessional References" />
+  <title value="zib HealthProfessional Reference" />
   <status value="draft" />
   <publisher value="Nictiz" />
   <contact>

--- a/resources/zib/zib-AddressInformation.xml
+++ b/resources/zib/zib-AddressInformation.xml
@@ -277,6 +277,7 @@
     <element id="Address.country.extension:countryCode">
       <path value="Address.country.extension" />
       <sliceName value="countryCode" />
+      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-CodeSpecification" />

--- a/resources/zib/zib-Patient.xml
+++ b/resources/zib/zib-Patient.xml
@@ -616,6 +616,7 @@
     <element id="Patient.communication.extension:comment">
       <path value="Patient.communication.extension" />
       <sliceName value="comment" />
+      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Comment" />


### PR DESCRIPTION
Kleine veegronde gedaan met een aanpassing aan de tool om te herkennen wanneer een element is gemapt op Extension.value[x] en daarom niet goed overweg kan met de kardinaliteit. Als gevolg daarvan twee situaties gevonden waarin de kardinaliteit echt niet klopt, en aangepast. Tevens de title van de pattern-profielen aangepast, omdat deze getoond worden in het hostende profiel.