### PR TITLE
QA improvements

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -4,6 +4,9 @@ on: pull_request
 jobs:
   validate-all:
     runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      markdown_report: ${{ steps.collect-statistics.outputs.markdown_report }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,7 +34,8 @@ jobs:
           key: fhir-cache
 
       - name: Validate zib profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-zib-profiles
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -39,8 +43,10 @@ jobs:
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles
           source:  ${{ steps.get-resources.outputs.zib_profiles }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate zib extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@master
+        id: validate-zib-extensions
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -48,8 +54,10 @@ jobs:
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions
           source:  ${{ steps.get-resources.outputs.zib_extensions }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate nl-core profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-nl-core-profiles
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -57,8 +65,10 @@ jobs:
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate nl-core extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-nl-core-extensions
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: ig/
@@ -66,8 +76,10 @@ jobs:
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions
           source:  ${{ steps.get-resources.outputs.nlcore_extensions }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate other profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-other-profiles
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -75,8 +87,10 @@ jobs:
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions
           source:  ${{ steps.get-resources.outputs.other_profiles }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate ConceptMaps
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-conceptmaps
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -84,32 +98,165 @@ jobs:
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-ConceptMaps
           source:  ${{ steps.get-resources.outputs.conceptmaps }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate other terminology
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-other-terminology
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           source:  ${{ steps.get-resources.outputs.other_terminology }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate examples
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-examples
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/
           recurse: true
           source:  ${{ steps.get-resources.outputs.examples }}
           ignored-issues: known-issues.yml
+        continue-on-error: true
+      - name: Collect results
+        id: collect-statistics
+        shell: python
+        run: |
+          import json, sys
 
+          success = True
+          github_report   = ""
+          markdown_report = ""
+
+          def printStatistics(name, key):
+            global success, github_report, markdown_report
+
+            global steps_data
+            step_data = steps_data[key]
+
+            if step_data["outputs"]["was-skipped"] == 'true':
+              out_str = f'Test "{name}" was skipped'
+              markdown_report += (f"- :heavy_minus_sign: _{out_str}_%0A")
+              return
+
+            step_success = (step_data["outcome"] == "success")
+            success = success and step_success
+
+            with open(step_data["outputs"]["stats-file"], 'r') as sf:
+              stats = json.load(sf)
+              
+              out_str = f'"{name}" {"succeeded" if step_success else "failed"} with {stats["fatal"]} fatal messages, {stats["error"]} errors, {stats["warning"]} warnings and {stats["information"]} information messages.'
+
+              if not step_success:
+                github_report   += f"::error::{out_str}%0A"
+                markdown_report += (f"- :x: {out_str}%0A")
+              elif stats["warning"] > 0:
+                github_report   += f"::warning::{out_str}%0A"
+                markdown_report += (f"- :warning: {out_str}%0A")
+              else:
+                github_report   += f"\033[1;32mOk:\033[0m {out_str}%0A"
+                markdown_report += (f"- :heavy_check_mark: {out_str}%0A")
+
+          steps_data = json.loads("""${{ toJSON(steps) }}""")
+
+          printStatistics("Validate zib profiles", "validate-zib-profiles")
+          printStatistics("Validate zib extensions", "validate-zib-extensions")
+          printStatistics("Validate nl-core profiles", "validate-nl-core-profiles")
+          printStatistics("Validate nl-core extensions", "validate-nl-core-extensions")
+          printStatistics("Validate other profiles", "validate-other-profiles")
+          printStatistics("Validate ConceptMaps", "validate-conceptmaps")
+          printStatistics("Validate other terminology", "validate-other-terminology")
+          printStatistics("Validate examples", "validate-examples")
+
+          print(f'::set-output name=result_status::{0 if success else 1}')
+          print(f'::set-output name=github_report::{github_report}')
+          print(f'::set-output name=markdown_report::{markdown_report}')
+      - name: Print results
+        run: |
+          echo "${{ steps.collect-statistics.outputs.github_report }}"
+          exit ${{ steps.collect-statistics.outputs.result_status }}
+
+  zib-compliance-all:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      markdown_report: ${{ steps.collect-statistics.outputs.markdown_report }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get profiles and extensions
+        id: get-resources
+        run: |
+          changed_only=0
+          source util/qaAutomation/getresources.sh
+          echo "::set-output name=zib_profiles::"$zib_profiles
+          echo "::set-output name=zib_extensions::"$zib_extensions
       - name: Install Firely Terminal
+        id: install-firely-terminal
         run: dotnet tool install -g --version 2.0.0 firely.terminal
       - name: Create snapshots in JSON format
+        id: create-snapshots
         run: bash util/qaAutomation/generatezibsnapshots.sh ${{ steps.get-resources.outputs.zib_profiles }} ${{ steps.get-resources.outputs.zib_extensions }}
       - name: Check zib compliance
+        id: check-zib-compliance
         uses: pieter-edelman-nictiz/zib-compliance-fhir@action
+        continue-on-error: true
         with:
           max-file: qa/zibs2020.max
           structuredefinitions: snapshots/*
           zib-release: 2020
           fail-at: warning
           zib-deviations: known-issues.yml
+      - name: Collect results
+        id: collect-statistics
+        shell: python
+        run: |
+          import json, sys
+
+          github_report   = ""
+          markdown_report = ""
+
+          success = ("${{ steps.check-zib-compliance.outcome }}" == "success")
+          with open("${{ steps.check-zib-compliance.outputs.stats-file }}", 'r') as sf:
+            if "${{ steps.check-zib-compliance.outputs.was-skipped }}" == 'true':
+              out_str = f'Zib compliance check was skipped'
+              markdown_report += (f"- :heavy_minus_sign: _{out_str}_%0A")
+            else:
+              stats = json.load(sf)
+              out_str = f'Zib compliance check {"succeeded" if success else "failed"} with {stats["error"]} errors and {stats["warning"]} warnings.'
+
+            if not success:
+              github_report   += f"::error::{out_str}%0A"
+              markdown_report += (f"- :x: {out_str}%0A")
+            else:
+              github_report   += f"\033[1;32mOk:\033[0m {out_str}%0A"
+              markdown_report += (f"- :heavy_check_mark: {out_str}%0A")
+
+          print(f'::set-output name=result_status::{0 if success else 1}')
+          print(f'::set-output name=github_report::{github_report}')
+          print(f'::set-output name=markdown_report::{markdown_report}')
+      - name: Print results
+        run: |
+          echo "${{ steps.collect-statistics.outputs.github_report }}"
+          exit ${{ steps.collect-statistics.outputs.result_status }}
+
+  attach-report:
+    runs-on: ubuntu-latest
+    needs: [validate-all, zib-compliance-all]
+    steps:
+      - name: Attach report to pull request
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            # Validation report
+
+            ## Validation
+            ${{ needs.validate-all.outputs.markdown_report }}
+
+            ## Zib compliance
+            ${{ needs.zib-compliance-all.outputs.markdown_report }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,6 +18,7 @@ jobs:
           echo "::set-output name=zib_profiles::"$zib_profiles
           echo "::set-output name=zib_extensions::"$zib_extensions
           echo "::set-output name=nlcore_profiles::"$nlcore_profiles
+          echo "::set-output name=nlcore_extensions::"$nlcore_extensions
           echo "::set-output name=other_profiles::"$other_profiles
           echo "::set-output name=conceptmaps::"$conceptmaps
           echo "::set-output name=other_terminology::"$other_terminology
@@ -57,8 +58,18 @@ jobs:
           version: "4.0"
           ig: ig/
           recurse: true
-          profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore
+          profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
+          fail-at: warning
+          ignored-issues: known-issues.yml
+      - name: Validate nl-core extensions
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        with:
+          version: "4.0"
+          ig: ig/
+          recurse: true
+          profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions
+          source:  ${{ steps.get-resources.outputs.nlcore_extensions }}
           fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate other profiles

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -38,17 +38,15 @@ jobs:
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles
           source:  ${{ steps.get-resources.outputs.zib_profiles }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate zib extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@master
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions
           source:  ${{ steps.get-resources.outputs.zib_extensions }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate nl-core profiles
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
@@ -58,7 +56,6 @@ jobs:
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate nl-core extensions
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
@@ -68,7 +65,6 @@ jobs:
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions
           source:  ${{ steps.get-resources.outputs.nlcore_extensions }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate other profiles
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
@@ -78,7 +74,6 @@ jobs:
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions
           source:  ${{ steps.get-resources.outputs.other_profiles }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate ConceptMaps
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
@@ -88,7 +83,6 @@ jobs:
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-ConceptMaps
           source:  ${{ steps.get-resources.outputs.conceptmaps }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate other terminology
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
@@ -97,7 +91,6 @@ jobs:
           ig: resources/ qa/
           recurse: true
           source:  ${{ steps.get-resources.outputs.other_terminology }}
-          fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate examples
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
@@ -106,7 +99,6 @@ jobs:
           ig: resources/
           recurse: true
           source:  ${{ steps.get-resources.outputs.examples }}
-          fail-at: warning
           ignored-issues: known-issues.yml
 
       - name: Install Firely Terminal

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -30,13 +30,11 @@ jobs:
           path: ~/.fhir/packages
           key: fhir-cache
 
-      - name: Create ig with the ProfileGuidelines resource
-        run: bash util/qaAutomation/mkprofilingig.sh
       - name: Validate zib profiles
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles
           source:  ${{ steps.get-resources.outputs.zib_profiles }}
@@ -46,7 +44,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions
           source:  ${{ steps.get-resources.outputs.zib_extensions }}
@@ -56,7 +54,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
@@ -76,7 +74,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions
           source:  ${{ steps.get-resources.outputs.other_profiles }}
@@ -86,7 +84,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-ConceptMaps
           source:  ${{ steps.get-resources.outputs.conceptmaps }}
@@ -96,7 +94,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           source:  ${{ steps.get-resources.outputs.other_terminology }}
           fail-at: warning

--- a/.github/workflows/validate-push.yml
+++ b/.github/workflows/validate-push.yml
@@ -30,13 +30,11 @@ jobs:
           path: ~/.fhir/packages
           key: fhir-cache
 
-      - name: Create ig with the ProfileGuidelines resources
-        run: bash util/qaAutomation/mkprofilingig.sh
       - name: Validate zib profiles
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles
           source:  ${{ steps.get-resources.outputs.zib_profiles }}
@@ -46,7 +44,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions
           source:  ${{ steps.get-resources.outputs.zib_extensions }}
@@ -56,7 +54,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
@@ -76,7 +74,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions
           source:  ${{ steps.get-resources.outputs.other_profiles }}
@@ -86,7 +84,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-ConceptMaps
           source:  ${{ steps.get-resources.outputs.conceptmaps }}
@@ -96,7 +94,7 @@ jobs:
         uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
         with:
           version: "4.0"
-          ig: ig/
+          ig: resources/ qa/
           recurse: true
           source:  ${{ steps.get-resources.outputs.other_terminology }}
           fail-at: warning

--- a/.github/workflows/validate-push.yml
+++ b/.github/workflows/validate-push.yml
@@ -18,6 +18,7 @@ jobs:
           echo "::set-output name=zib_profiles::"$zib_profiles
           echo "::set-output name=zib_extensions::"$zib_extensions
           echo "::set-output name=nlcore_profiles::"$nlcore_profiles
+          echo "::set-output name=nlcore_extensions::"$nlcore_extensions
           echo "::set-output name=other_profiles::"$other_profiles
           echo "::set-output name=conceptmaps::"$conceptmaps
           echo "::set-output name=other_terminology::"$other_terminology
@@ -57,8 +58,18 @@ jobs:
           version: "4.0"
           ig: ig/
           recurse: true
-          profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore
+          profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
+          fail-at: warning
+          ignored-issues: known-issues.yml
+      - name: Validate nl-core extensions
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        with:
+          version: "4.0"
+          ig: ig/
+          recurse: true
+          profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions
+          source:  ${{ steps.get-resources.outputs.nlcore_extensions }}
           fail-at: warning
           ignored-issues: known-issues.yml
       - name: Validate other profiles

--- a/.github/workflows/validate-push.yml
+++ b/.github/workflows/validate-push.yml
@@ -31,93 +31,197 @@ jobs:
           key: fhir-cache
 
       - name: Validate zib profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-zib-profiles
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles
           source:  ${{ steps.get-resources.outputs.zib_profiles }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate zib extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-zib-extensions
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions
           source:  ${{ steps.get-resources.outputs.zib_extensions }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate nl-core profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-nl-core-profiles
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles
           source:  ${{ steps.get-resources.outputs.nlcore_profiles }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate nl-core extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-nl-core-extensions
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: ig/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions
           source:  ${{ steps.get-resources.outputs.nlcore_extensions }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate other profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-other-profiles
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions
           source:  ${{ steps.get-resources.outputs.other_profiles }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate ConceptMaps
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-conceptmaps
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           profile: http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-ConceptMaps
           source:  ${{ steps.get-resources.outputs.conceptmaps }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate other terminology
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-other-terminology
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/ qa/
           recurse: true
           source:  ${{ steps.get-resources.outputs.other_terminology }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
       - name: Validate examples
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.15
+        id: validate-examples
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.16
         with:
           version: "4.0"
           ig: resources/
           recurse: true
           source:  ${{ steps.get-resources.outputs.examples }}
-          fail-at: warning
           ignored-issues: known-issues.yml
+        continue-on-error: true
+      - name: Collect results
+        id: collect-statistics
+        shell: python
+        run: |
+          import json, sys
 
+          success = True
+          github_report   = ""
+
+          def printStatistics(name, key):
+            global success, github_report, markdown_report
+
+            global steps_data
+            step_data = steps_data[key]
+
+            if step_data["outputs"]["was-skipped"] == 'true':
+              out_str = f'Test "{name}" was skipped'
+              return
+
+            step_success = (step_data["outcome"] == "success")
+            success = success and step_success
+
+            with open(step_data["outputs"]["stats-file"], 'r') as sf:
+              stats = json.load(sf)
+              
+              out_str = f'"{name}" {"succeeded" if step_success else "failed"} with {stats["fatal"]} fatal messages, {stats["error"]} errors, {stats["warning"]} warnings and {stats["information"]} information messages.'
+
+              if not step_success:
+                github_report   += f"::error::{out_str}%0A"
+              elif stats["warning"] > 0:
+                github_report   += f"::warning::{out_str}%0A"
+              else:
+                github_report   += f"\033[1;32mOk:\033[0m {out_str}%0A"
+
+          steps_data = json.loads("""${{ toJSON(steps) }}""")
+
+          printStatistics("Validate zib profiles", "validate-zib-profiles")
+          printStatistics("Validate zib extensions", "validate-zib-extensions")
+          printStatistics("Validate nl-core profiles", "validate-nl-core-profiles")
+          printStatistics("Validate nl-core extensions", "validate-nl-core-extensions")
+          printStatistics("Validate other profiles", "validate-other-profiles")
+          printStatistics("Validate ConceptMaps", "validate-conceptmaps")
+          printStatistics("Validate other terminology", "validate-other-terminology")
+          printStatistics("Validate examples", "validate-examples")
+
+          print(f'::set-output name=result_status::{0 if success else 1}')
+          print(f'::set-output name=github_report::{github_report}')
+      - name: Print results
+        run: |
+          echo "${{ steps.collect-statistics.outputs.github_report }}"
+          exit ${{ steps.collect-statistics.outputs.result_status }}
+
+  zib-compliance-changed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get profiles and extensions
+        id: get-resources
+        run: |
+          changed_only=1
+          source util/qaAutomation/getresources.sh
+          echo "::set-output name=zib_profiles::"$zib_profiles
+          echo "::set-output name=zib_extensions::"$zib_extensions
       - name: Install Firely Terminal
+        id: install-firely-terminal
         run: dotnet tool install -g --version 2.0.0 firely.terminal
       - name: Create snapshots in JSON format
+        id: create-snapshots
         run: bash util/qaAutomation/generatezibsnapshots.sh ${{ steps.get-resources.outputs.zib_profiles }} ${{ steps.get-resources.outputs.zib_extensions }}
       - name: Check zib compliance
+        id: check-zib-compliance
         uses: pieter-edelman-nictiz/zib-compliance-fhir@action
+        continue-on-error: true
         with:
           max-file: qa/zibs2020.max
           structuredefinitions: snapshots/*
           zib-release: 2020
           fail-at: warning
           zib-deviations: known-issues.yml
+      - name: Collect results
+        id: collect-statistics
+        shell: python
+        run: |
+          import json, sys
+
+          github_report   = ""
+
+          success = ("${{ steps.check-zib-compliance.outcome }}" == "success")
+          with open("${{ steps.check-zib-compliance.outputs.stats-file }}", 'r') as sf:
+            if "${{ steps.check-zib-compliance.outputs.was-skipped }}" == 'true':
+              out_str = f'Zib compliance check was skipped'
+            else:
+              stats = json.load(sf)
+              out_str = f'Zib compliance check {"succeeded" if success else "failed"} with {stats["error"]} errors and {stats["warning"]} warnings.'
+
+            if not success:
+              github_report   += f"::error::{out_str}%0A"
+            else:
+              github_report   += f"\033[1;32mOk:\033[0m {out_str}%0A"
+
+          print(f'::set-output name=result_status::{0 if success else 1}')
+          print(f'::set-output name=github_report::{github_report}')
+      - name: Print results
+        run: |
+          echo "${{ steps.collect-statistics.outputs.github_report }}"
+          exit ${{ steps.collect-statistics.outputs.result_status }}

--- a/qa/ProfilingGuidelinesR4-ConceptMaps.xml
+++ b/qa/ProfilingGuidelinesR4-ConceptMaps.xml
@@ -5,6 +5,7 @@
   <name value="ProfilingGuidelinesR4_ConceptMaps" />
   <title value="ConceptMap conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check ConceptMaps for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4)."/>
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions.xml
@@ -2,9 +2,10 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions" />
-  <name value="ProfilingGuidelinesR4StructureDefinitionsNlCore-Extensions" />
+  <name value="ProfilingGuidelinesR4StructureDefinitionsNlCoreExtensions" />
   <title value="nl-core extension conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check extensions that implement a specific funcrtional concept at the nl-core layer for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4). Such extensions are recognized by the name, consisting of &quot;ext-[FunctionalModelName].[ConceptName]&quot;." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions" />
+  <name value="ProfilingGuidelinesR4StructureDefinitionsNlCore-Extensions" />
+  <title value="nl-core extension conformance to FHIR Profiling Guidelines for FHIR R4" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="StructureDefinition" />
+  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="StructureDefinition">
+      <path value="StructureDefinition" />
+      <constraint>
+        <key value="sd-zpg-e-01" />
+        <severity value="error" />
+        <human value="StuctureDefinition.id should start with 'ext-'" />
+        <expression value="StructureDefinition.id.startsWith('ext-')" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles" />
+  <name value="ProfilingGuidelinesR4StructureDefinitionsNlCore-Profiles" />
+  <title value="nl-core StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
+  <status value="draft" />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="StructureDefinition" />
+  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="StructureDefinition">
+      <path value="StructureDefinition" />
+      <constraint>
+        <key value="sd-zpg-01" />
+        <severity value="error" />
+        <human value="StuctureDefinition.id should start with 'nl-core-'" />
+        <expression value="StructureDefinition.id.startsWith('nl-core-')" />
+        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
+      </constraint>
+      <constraint>
+        <key value="sd-zpg-03" />
+        <severity value="error" />
+        <human value="Root element should have the profile id as alias" />
+        <expression value="StructureDefinition.id in StructureDefinition.differential.element[0].alias" />
+        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
+      </constraint>
+    </element>
+    <element id="StructureDefinition.purpose">
+      <path value="StructureDefinition.purpose" />
+      <min value="1" />
+      <constraint>
+        <key value="sd-pgnc-01" />
+        <severity value="error" />
+        <human value="The purpose field should conform to the profiling guidelines." />
+        <expression value="$this.matches('A derived profile from \\[.*\\]\\(http:\\/\\/nictiz\\.nl\\/fhir\\/StructureDefinition\\/.*\\) to provide a version better suited for implementation purposes\\. This profile augments the base profile with elements found in the various use cases that have adopted the zib\\.((\\r?\\n){2}.+)?')" />
+        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
+      </constraint>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles.xml
@@ -2,9 +2,10 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles" />
-  <name value="ProfilingGuidelinesR4StructureDefinitionsNlCore-Profiles" />
+  <name value="ProfilingGuidelinesR4StructureDefinitionsNlCoreProfiles" />
   <title value="nl-core StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check &quot;normal&quot; profiles (i.e. not extensions) at the nl-core layer for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4)." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />
@@ -19,7 +20,6 @@
         <severity value="error" />
         <human value="StuctureDefinition.id should start with 'nl-core-'" />
         <expression value="StructureDefinition.id.startsWith('nl-core-')" />
-        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
       </constraint>
       <constraint>
         <key value="sd-zpg-03" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore.xml
@@ -35,10 +35,16 @@
         <expression value="StructureDefinition.id in StructureDefinition.differential.element[0].alias" />
         <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
       </constraint>
+      <constraint>
+        <key value="sd-zpg-04" />
+        <severity value="error" />
+        <human value="Purpose element should be present for nl-core profiles while this is not required for extensions" />
+        <expression value="StructureDefinition.id.startsWith('nl-core-') implies StructureDefinition.purpose.exists()" />
+        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
+      </constraint>
     </element>
     <element id="StructureDefinition.purpose">
       <path value="StructureDefinition.purpose" />
-      <min value="1" />
       <constraint>
         <key value="sd-pgnc-01" />
         <severity value="error" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore.xml
@@ -5,6 +5,7 @@
   <name value="ProfilingGuidelinesR4StructureDefinitionsNlCore" />
   <title value="nl-core StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check profiles at the nl-core layer for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4)." />
   <fhirVersion value="4.0.1" />
   <kind value="resource" />
   <abstract value="false" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-NlCore.xml
@@ -17,39 +17,8 @@
       <constraint>
         <key value="sd-zpg-01" />
         <severity value="error" />
-        <human value="StuctureDefinition.id should start with 'nl-core-' or 'ext-nl-core'" />
-        <expression value="StructureDefinition.id.startsWith('nl-core-') or StructureDefinition.id.startsWith('ext-nl-core-')" />
-        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
-      </constraint>
-      <constraint>
-        <key value="sd-zpg-02" />
-        <severity value="error" />
-        <human value="StuctureDefinition.id should start 'ext-zib' if it defines an Extension" />
-        <expression value="StructureDefinition.type = 'Extension' implies StructureDefinition.id.startsWith('ext-nl-core-')" />
-        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
-      </constraint>
-      <constraint>
-        <key value="sd-zpg-03" />
-        <severity value="error" />
-        <human value="Root element should have the profile id as alias" />
-        <expression value="StructureDefinition.id in StructureDefinition.differential.element[0].alias" />
-        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
-      </constraint>
-      <constraint>
-        <key value="sd-zpg-04" />
-        <severity value="error" />
-        <human value="Purpose element should be present for nl-core profiles while this is not required for extensions" />
-        <expression value="StructureDefinition.id.startsWith('nl-core-') implies StructureDefinition.purpose.exists()" />
-        <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
-      </constraint>
-    </element>
-    <element id="StructureDefinition.purpose">
-      <path value="StructureDefinition.purpose" />
-      <constraint>
-        <key value="sd-pgnc-01" />
-        <severity value="error" />
-        <human value="The purpose field should conform to the profiling guidelines." />
-        <expression value="$this.matches('A derived profile from \\[.*\\]\\(http:\\/\\/nictiz\\.nl\\/fhir\\/StructureDefinition\\/.*\\) to provide a version better suited for implementation purposes\\. This profile augments the base profile with elements found in the various use cases that have adopted the zib\\.((\\r?\\n){2}.+)?')" />
+        <human value="StuctureDefinition.id should start with 'nl-core-' or 'ext-'" />
+        <expression value="StructureDefinition.id.startsWith('nl-core-') or StructureDefinition.id.startsWith('ext-')" />
         <source value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore" />
       </constraint>
     </element>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions.xml
@@ -4,6 +4,7 @@
   <name value="ProfilingGuidelinesR4StructureDefinitionsZibExtensions" />
   <title value="Zib StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check extensions that implement a specific funcrtional concept at the zib layer for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4). Such extensions are recognized by the name, consisting of &quot;ext-[ZibName].[ConceptName]&quot;." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -37,7 +38,7 @@
   <derivation value="constraint" />
   <differential>
     <element id="StructureDefinition">
-      <path value="StructureDefinition"/>
+      <path value="StructureDefinition" />
       <constraint>
         <key value="sd-zpg-e-01" />
         <severity value="error" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles.xml
@@ -5,6 +5,7 @@
   <name value="ProfilingGuidelinesR4StructureDefinitionsZibProfiles" />
   <title value="Zib StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check &quot;normal&quot; zib profiles (i.e. not extensions) for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4)." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -38,7 +39,7 @@
   <derivation value="constraint" />
   <differential>
     <element id="StructureDefinition">
-      <path value="StructureDefinition"/>
+      <path value="StructureDefinition" />
       <constraint>
         <key value="sd-zpg-p-01" />
         <severity value="error" />

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles.xml
@@ -58,5 +58,15 @@
       <path value="StructureDefinition.abstract" />
       <fixedBoolean value="true" />
     </element>
+    <element id="StructureDefinition.differential.element.type">
+      <path value="StructureDefinition.differential.element.type" />
+      <constraint>
+        <key value="sd-zpg-03" />
+        <severity value="error" />
+        <human value="References to other resource profiles should be added next to the HL7  base references." />
+        <expression value="code = 'Reference' implies targetProfile.where($this.startsWith('http://hl7.org/fhir/StructureDefinition/')).exists()" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4#Constraining_references" />
+      </constraint>
+    </element>
   </differential>
 </StructureDefinition>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
@@ -94,14 +94,11 @@
         <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies alias.exists()"/>
         <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
       </constraint>
-    </element>
-    <element id="StructureDefinition.differential.element.type">
-      <path value="StructureDefinition.differential.element.type" />
       <constraint>
         <key value="sd-zpg-03" />
         <severity value="error" />
-        <human value="References to other resource profiles should be added next to the HL7  base references." />
-        <expression value="code = 'Reference' implies targetProfile.where($this.startsWith('http://hl7.org/fhir/StructureDefinition/')).exists()" />
+        <human value="References to other resource profiles should be added next to the HL7  base references. This does not apply for extensions." />
+        <expression value="$this.where(type.code = 'Reference' and path.contains('Extension').not()).exists() implies $this.type.targetProfile.where($this.startsWith('http://hl7.org/fhir/StructureDefinition/')).exists()" />
         <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4#Constraining_references" />
       </constraint>
     </element>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
@@ -5,6 +5,7 @@
   <name value="ProfilingGuidelinesR4StructureDefinitionsZib" />
   <title value="Zib StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
   <status value="draft" />
+  <description value="Conformance profile to check zib profiles for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4)." />
   <fhirVersion value="4.0.1" />
   <mapping>
     <identity value="rim" />
@@ -69,30 +70,30 @@
       <path value="StructureDefinition.differential.element" />
       <constraint>
         <key value="sd-zpg-08" />
-        <severity value="error"/>
+        <severity value="error" />
         <human value="If an alias exists, mapping.map needs to be present." />
         <expression value="alias.exists() implies mapping.map.exists()" />
-        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
       </constraint>
       <constraint>
-        <key value="sd-pg-02"/>
-        <human value="If mapping.map exists and the mapping is not implicit, short should exist"/>
-        <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies short.exists()"/>
-        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+        <key value="sd-pg-02" />
+        <human value="If mapping.map exists and the mapping is not implicit, short should exist" />
+        <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies short.exists()" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
       </constraint>
       <constraint>
-        <key value="sd-pg-03"/>
-        <severity value="error"/>
-        <human value="If mapping.map exists and the mapping is not implicit and the element is not the root element, definition should exist."/>
-        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.indexOf('.') != -1) implies definition.exists()"/>
-        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+        <key value="sd-pg-03" />
+        <severity value="error" />
+        <human value="If mapping.map exists and the mapping is not implicit and the element is not the root element, definition should exist." />
+        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.indexOf('.') != -1) implies definition.exists()" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
       </constraint>
       <constraint>
-        <key value="sd-pg-04"/>
-        <severity value="error"/>
-        <human value="If mapping.map exists and the mapping is not implicit, alias should exist."/>
-        <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies alias.exists()"/>
-        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+        <key value="sd-pg-04" />
+        <severity value="error" />
+        <human value="If mapping.map exists and the mapping is not implicit, alias should exist." />
+        <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies alias.exists()" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
       </constraint>
     </element>
   </differential>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
@@ -94,13 +94,6 @@
         <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies alias.exists()"/>
         <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
       </constraint>
-      <constraint>
-        <key value="sd-zpg-03" />
-        <severity value="error" />
-        <human value="References to other resource profiles should be added next to the HL7  base references. This does not apply for extensions." />
-        <expression value="$this.where(type.code = 'Reference' and path.contains('Extension').not()).exists() implies $this.type.targetProfile.where($this.startsWith('http://hl7.org/fhir/StructureDefinition/')).exists()" />
-        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4#Constraining_references" />
-      </constraint>
     </element>
   </differential>
 </StructureDefinition>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
@@ -69,10 +69,30 @@
       <path value="StructureDefinition.differential.element" />
       <constraint>
         <key value="sd-zpg-08" />
-        <severity value="error" />
+        <severity value="error"/>
         <human value="If an alias exists, mapping.map needs to be present." />
         <expression value="alias.exists() implies mapping.map.exists()" />
-        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+      </constraint>
+      <constraint>
+        <key value="sd-pg-02"/>
+        <human value="If mapping.map exists and the mapping is not implicit, short should exist"/>
+        <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies short.exists()"/>
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+      </constraint>
+      <constraint>
+        <key value="sd-pg-03"/>
+        <severity value="error"/>
+        <human value="If mapping.map exists and the mapping is not implicit and the element is not the root element, definition should exist."/>
+        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.indexOf('.') != -1) implies definition.exists()"/>
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
+      </constraint>
+      <constraint>
+        <key value="sd-pg-04"/>
+        <severity value="error"/>
+        <human value="If mapping.map exists and the mapping is not implicit, alias should exist."/>
+        <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies alias.exists()"/>
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
       </constraint>
     </element>
     <element id="StructureDefinition.differential.element.type">

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-    <id value="ProfilingGuidelinesR4-StructureDefinitions"/>
-    <url value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions"/>
-    <name value="ProfilingGuidelinesR4-StructureDefinitions"/>
-    <title value="StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4"/>
-    <status value="draft"/>
-    <experimental value="true"/>
-    <publisher value="Nictiz"/>
-    <contact>
-        <name value="Nictiz"/>
-        <telecom>
-            <system value="email"/>
-            <value value="info@nictiz.nl"/>
-            <use value="work"/>
-        </telecom>
-    </contact>
-    <description value="Profile to validate against Profiling Guidlines for R4."/>
-    <purpose value="For QA on the StructureDefinitions created for R4."/>
-    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
-    <fhirVersion value="4.0.1"/>
-    <mapping>
-        <identity value="rim"/>
-        <uri value="http://hl7.org/v3"/>
-        <name value="RIM Mapping"/>
-    </mapping>
-    <mapping>
-        <identity value="workflow"/>
-        <uri value="http://hl7.org/fhir/workflow"/>
-        <name value="Workflow Pattern"/>
-    </mapping>
-    <mapping>
-        <identity value="w5"/>
-        <uri value="http://hl7.org/fhir/fivews"/>
-        <name value="FiveWs Pattern Mapping"/>
-    </mapping>
-    <mapping>
-        <identity value="iso11179"/>
-        <uri value="http://metadata-standards.org/11179/"/>
-        <name value="ISO 11179"/>
-    </mapping>
-    <mapping>
-        <identity value="objimpl"/>
-        <uri value="http://hl7.org/fhir/object-implementation"/>
-        <name value="Object Implementation Information"/>
-    </mapping>
-    <kind value="resource"/>
-    <abstract value="false"/>
-    <type value="StructureDefinition"/>
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/StructureDefinition"/>
-    <derivation value="constraint"/>
-    <differential>
-        <element id="StructureDefinition">
-            <path value="StructureDefinition"/>
+  <id value="ProfilingGuidelinesR4-StructureDefinitions" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions" />
+  <name value="ProfilingGuidelinesR4StructureDefinitions" />
+  <title value="StructureDefinition conformance to FHIR Profiling Guidelines for FHIR R4" />
+  <status value="draft" />
+  <experimental value="true" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Conformance profile to check profiles for conformance to the [Nictiz profiling guidelines for FHIR R4](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4).&#xD;&#xA;&#xD;&#xA;This profile contains the common rules for all profiles. Checks for specific situations (extensions, different layers, etc.) are implemented using derived profiles." />
+  <purpose value="For QA on the StructureDefinitions created for R4." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="workflow" />
+    <uri value="http://hl7.org/fhir/workflow" />
+    <name value="Workflow Pattern" />
+  </mapping>
+  <mapping>
+    <identity value="w5" />
+    <uri value="http://hl7.org/fhir/fivews" />
+    <name value="FiveWs Pattern Mapping" />
+  </mapping>
+  <mapping>
+    <identity value="iso11179" />
+    <uri value="http://metadata-standards.org/11179/" />
+    <name value="ISO 11179" />
+  </mapping>
+  <mapping>
+    <identity value="objimpl" />
+    <uri value="http://hl7.org/fhir/object-implementation" />
+    <name value="Object Implementation Information" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="StructureDefinition" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/StructureDefinition" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="StructureDefinition">
+      <path value="StructureDefinition" />
             <constraint>
                 <key value="sd-pg-01"/>
                 <severity value="warning"/>
@@ -81,139 +81,119 @@
                 <expression value="StructureDefinition.title = StructureDefinition.id.replace('-',' ')"/>
                 <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
             </constraint>
-            <constraint>
-                <key value="sd-pg-09"/>
-                <severity value="error"/>
-                <human value="When a mapping is defined in the profile, it should be used on one or more of the elements."/>
-                <expression value="mapping.identity.subsetOf(%resource.differential.element.mapping.identity)"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-            <constraint>
-                <key value="sd-pg-10"/>
-                <severity value="error"/>
-                <human value="When a mapping is defined on an element, it should be declared in the profile."/>
-                <expression value="differential.element.mapping.identity.subsetOf(%resource.mapping.identity)"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-        </element>
-        <element id="StructureDefinition.url">
-            <path value="StructureDefinition.url"/>
-            <definition value="The canonical URL, which is the external identifier for conformance resources. All conformance resources SHALL have a canonical URL. This URL is preferably resolvable but does not have to be processable. Canonical URL's are about the identity of artifacts, not necessarily about retrieval location. Canonical URLs aren't meant to be human recognizable. The canonical URL will be created as: http://nictiz.nl/fhir/StructureDefinition/[id]"/>
-        </element>
-        <element id="StructureDefinition.name">
-            <path value="StructureDefinition.name"/>
-            <definition value="A recognizable name that is still computer processable. The name will be the .id capitalized, with hyphens removed."/>
-        </element>
-        <element id="StructureDefinition.title">
-            <path value="StructureDefinition.title"/>
-            <definition value="A recognizable title purely for human consumption. The title will generally be the .id with hyphens replaced by spaces."/>
-            <min value="1"/>
-        </element>
-        <element id="StructureDefinition.publisher">
-            <path value="StructureDefinition.publisher"/>
-            <min value="1"/>
-            <max value="1"/>
-            <fixedString value="Nictiz"/>
-        </element>
-        <element id="StructureDefinition.contact">
-            <path value="StructureDefinition.contact"/>
-            <min value="1"/>
-            <max value="1"/>
-        </element>
-        <element id="StructureDefinition.contact.name">
-            <path value="StructureDefinition.contact.name"/>
-            <min value="1"/>
-            <fixedString value="Nictiz"/>
-        </element>
-        <element id="StructureDefinition.contact.telecom">
-            <path value="StructureDefinition.contact.telecom"/>
-            <patternContactPoint>
-                <system value="email"/>
-                <value value="info@nictiz.nl"/>
-                <use value="work"/>
-            </patternContactPoint>
-            <min value="1"/>
-            <max value="1"/>
-        </element>
-        <element id="StructureDefinition.description">
-            <path value="StructureDefinition.description"/>
-            <definition value="For profiles:
-                - For zib profiles: the 'Concept' section from the zib.
-                - For uniprofiles: TBD
-                - For standard specific profiles: TBD
-                For extensions:
-                - A description of what the extension is for."/>
-            <min value="1"/>
-        </element>
-        <element id="StructureDefinition.purpose">
-            <path value="StructureDefinition.purpose"/>
-            <definition value="For profiles:
-                - For zib profiles: This [enter resource type] resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) [English zib name] [version]([release])]([link to the English zib page on zibs.nl]).
-                - For uniprofiles: A derived profile from [[id of zib profile]]([canonical of zib profile]) to provide a version better suited for implementation purposes. This profile augments the base profile with common elements found in the various use cases that have adopted the zib.
-                - For standard specific profiles: A description with a reference to the base profile, with an explanation of why it has been added.
-                For extensions:
-                - For extension representing a specific concept: This extension represents the [concept name] of ..., followed by a link to the functional description.
-                - For other extensions this will likely be absent."/>
-        </element>
-        <element id="StructureDefinition.copyright">
-            <path value="StructureDefinition.copyright"/>
-            <min value="1"/>
-            <fixedMarkdown value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
-        </element>
-        <element id="StructureDefinition.fhirVersion">
-            <path value="StructureDefinition.fhirVersion"/>
-            <min value="1"/>
-            <fixedCode value="4.0.1"/>
-        </element>
-        <element id="StructureDefinition.mapping.uri">
-            <path value="StructureDefinition.mapping.uri"/>
-            <min value="1"/>
-        </element>
-        <element id="StructureDefinition.mapping.name">
-            <path value="StructureDefinition.mapping.name"/>
-            <min value="1"/>
-        </element>
-        <element id="StructureDefinition.baseDefinition">
-            <path value="StructureDefinition.baseDefinition"/>
-            <min value="1"/>
-        </element>
-        <element id="StructureDefinition.snapshot">
-            <path value="StructureDefinition.snapshot"/>
-            <max value="0"/>
-        </element>
-        <element id="StructureDefinition.differential.element">
-            <path value="StructureDefinition.differential.element"/>
-            <constraint>
-                <key value="sd-pg-11"/>
-                <severity value="error"/>
-                <human value="If an alias exists and this element is not the root element, mapping.map needs to be present."/>
-                <expression value="(alias.exists() and $this.indexOf('.') != -1) implies mapping.map.exists()"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-        </element>
-        <element id="StructureDefinition.differential.element.sliceName">
-            <path value="StructureDefinition.differential.element.sliceName"/>
-            <constraint>
-                <key value="sd-pg-13"/>
-                <severity value="warning"/>
-                <human value="Slice names should be camelCased starting with a lowercase letter."/>
-                <expression value="$this.substring(0, 1).matches('[a-z]')"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-        </element>
-        <element id="StructureDefinition.differential.element.binding">
-            <path value="StructureDefinition.differential.element.binding"/>
-            <constraint>
-                <key value="sd-pg-05"/>
-                <severity value="error"/>
-                <human value="If a ConceptMap is defined for a binding, it should be mentioned in the description."/>
-                <expression value="valueSet.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap').exists() implies description.contains('ConceptMap')"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-        </element>
-        <element id="StructureDefinition.differential.element.mapping.comment">
-            <path value="StructureDefinition.differential.element.mapping.comment"/>
-            <min value="1"/>
-        </element>
-    </differential>
+      <constraint>
+        <key value="sd-pg-09" />
+        <severity value="error" />
+        <human value="When a mapping is defined in the profile, it should be used on one or more of the elements." />
+        <expression value="mapping.identity.subsetOf(%resource.differential.element.mapping.identity)" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+      </constraint>
+      <constraint>
+        <key value="sd-pg-10" />
+        <severity value="error" />
+        <human value="When a mapping is defined on an element, it should be declared in the profile." />
+        <expression value="differential.element.mapping.identity.subsetOf(%resource.mapping.identity)" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+      </constraint>
+    </element>
+    <element id="StructureDefinition.url">
+      <path value="StructureDefinition.url" />
+    </element>
+    <element id="StructureDefinition.name">
+      <path value="StructureDefinition.name" />
+    </element>
+    <element id="StructureDefinition.title">
+      <path value="StructureDefinition.title" />
+      <min value="1" />
+    </element>
+    <element id="StructureDefinition.publisher">
+      <path value="StructureDefinition.publisher" />
+      <min value="1" />
+      <fixedString value="Nictiz" />
+    </element>
+    <element id="StructureDefinition.contact">
+      <path value="StructureDefinition.contact" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="StructureDefinition.contact.name">
+      <path value="StructureDefinition.contact.name" />
+      <min value="1" />
+      <fixedString value="Nictiz" />
+    </element>
+    <element id="StructureDefinition.contact.telecom">
+      <path value="StructureDefinition.contact.telecom" />
+      <min value="1" />
+      <max value="1" />
+      <patternContactPoint>
+        <system value="email" />
+        <value value="info@nictiz.nl" />
+        <use value="work" />
+      </patternContactPoint>
+    </element>
+    <element id="StructureDefinition.description">
+      <path value="StructureDefinition.description" />
+      <min value="1" />
+    </element>
+    <element id="StructureDefinition.copyright">
+      <path value="StructureDefinition.copyright" />
+      <min value="1" />
+      <fixedMarkdown value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+    </element>
+    <element id="StructureDefinition.fhirVersion">
+      <path value="StructureDefinition.fhirVersion" />
+      <min value="1" />
+      <fixedCode value="4.0.1" />
+    </element>
+    <element id="StructureDefinition.mapping.uri">
+      <path value="StructureDefinition.mapping.uri" />
+      <min value="1" />
+    </element>
+    <element id="StructureDefinition.mapping.name">
+      <path value="StructureDefinition.mapping.name" />
+      <min value="1" />
+    </element>
+    <element id="StructureDefinition.baseDefinition">
+      <path value="StructureDefinition.baseDefinition" />
+      <min value="1" />
+    </element>
+    <element id="StructureDefinition.snapshot">
+      <path value="StructureDefinition.snapshot" />
+      <max value="0" />
+    </element>
+    <element id="StructureDefinition.differential.element">
+      <path value="StructureDefinition.differential.element" />
+      <constraint>
+        <key value="sd-pg-11" />
+        <severity value="error" />
+        <human value="If an alias exists and this element is not the root element, mapping.map needs to be present." />
+        <expression value="(alias.exists() and $this.indexOf('.') != -1) implies mapping.map.exists()" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+      </constraint>
+    </element>
+    <element id="StructureDefinition.differential.element.sliceName">
+      <path value="StructureDefinition.differential.element.sliceName" />
+      <constraint>
+        <key value="sd-pg-13" />
+        <severity value="warning" />
+        <human value="Slice names should be camelCased starting with a lowercase letter." />
+        <expression value="$this.substring(0, 1).matches('[a-z]')" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+      </constraint>
+    </element>
+    <element id="StructureDefinition.differential.element.binding">
+      <path value="StructureDefinition.differential.element.binding" />
+      <constraint>
+        <key value="sd-pg-05" />
+        <severity value="error" />
+        <human value="If a ConceptMap is defined for a binding, it should be mentioned in the description." />
+        <expression value="valueSet.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap').exists() implies description.contains('ConceptMap')" />
+        <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
+      </constraint>
+    </element>
+    <element id="StructureDefinition.differential.element.mapping.comment">
+      <path value="StructureDefinition.differential.element.mapping.comment" />
+      <min value="1" />
+    </element>
+  </differential>
 </StructureDefinition>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions.xml
@@ -184,27 +184,6 @@
         <element id="StructureDefinition.differential.element">
             <path value="StructureDefinition.differential.element"/>
             <constraint>
-                <key value="sd-pg-02"/>
-                <severity value="error"/>
-                <human value="If mapping.map exists and the mapping is not implicit, short should exist"/>
-                <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies short.exists()"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-            <constraint>
-                <key value="sd-pg-03"/>
-                <severity value="error"/>
-                <human value="If mapping.map exists and the mapping is not implicit and the element is not the root element, definition should exist."/>
-                <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.indexOf('.') != -1) implies definition.exists()"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-            <constraint>
-                <key value="sd-pg-04"/>
-                <severity value="error"/>
-                <human value="If mapping.map exists and the mapping is not implicit, alias should exist."/>
-                <expression value="mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() implies alias.exists()"/>
-                <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4"/>
-            </constraint>
-            <constraint>
                 <key value="sd-pg-11"/>
                 <severity value="error"/>
                 <human value="If an alias exists and this element is not the root element, mapping.map needs to be present."/>

--- a/util/qaAutomation/Dockerfile
+++ b/util/qaAutomation/Dockerfile
@@ -28,10 +28,9 @@ RUN apt-get -y install dos2unix
 RUN mkdir /scripts
 COPY getresources.sh /scripts/getresources.sh
 COPY checktx.sh /scripts/checktx.sh
-COPY mkprofilingig.sh /scripts/mkprofilingig.sh
 COPY generatezibsnapshots.sh /scripts/generatezibsnapshots.sh
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 RUN chmod +x /scripts/*.sh
-RUN dos2unix /scripts/getresources.sh /scripts/checktx.sh /scripts/mkprofilingig.sh /scripts/generatezibsnapshots.sh entrypoint.sh
+RUN dos2unix /scripts/getresources.sh /scripts/checktx.sh /scripts/generatezibsnapshots.sh entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]

--- a/util/qaAutomation/entrypoint.sh
+++ b/util/qaAutomation/entrypoint.sh
@@ -32,7 +32,6 @@ while [ "$1" != "" ]; do
 done
 
 source /scripts/getresources.sh
-source /scripts/mkprofilingig.sh
 
 # Run the HL7 Validator and analyze the output. Parameters:
 # $1: textual description of the resources being analyzed
@@ -48,7 +47,7 @@ validate() {
     if [[ -n $3 ]]; then
       local profile_opt="-profile $3"
     fi
-    eval java -jar $tools_dir/validator/validator.jar -version 4.0 -ig ig/ -recurse $profile_opt $tx_opt $2 -output $output $output_redirect
+    eval java -jar $tools_dir/validator/validator.jar -version 4.0 -ig qa/ -ig resources/ -recurse $profile_opt $tx_opt $2 -output $output $output_redirect
     if [ $? -eq 0 ]; then
       python3 $tools_dir/hl7-fhir-validator-action/analyze_results.py --colorize --fail-at warning --ignored-issues known-issues.yml $output
       if [ "$tx_opt" != "" ]; then

--- a/util/qaAutomation/entrypoint.sh
+++ b/util/qaAutomation/entrypoint.sh
@@ -74,7 +74,8 @@ else
 fi
 validate "zib profiles" "$zib_profiles" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Profiles"
 validate "zib extensions" "$zib_extensions" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-Zib-Extensions"
-validate "nl-core profiles" "$nlcore_profiles" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore"
+validate "nl-core profiles" "$nlcore_profiles" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Profiles"
+validate "nl-core extensions" "$nlcore_extensions" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions-NlCore-Extensions"
 validate "other profiles" "$other_profiles" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-StructureDefinitions"
 validate "ConceptMaps" "$conceptmaps" "http://nictiz.nl/fhir/StructureDefinition/ProfilingGuidelinesR4-ConceptMaps"
 validate "other terminology" "$other_terminology"

--- a/util/qaAutomation/getresources.sh
+++ b/util/qaAutomation/getresources.sh
@@ -2,7 +2,8 @@
 
 # If changed_only is set to not null, then we only check the changed files, otherwise the full set.
 if [[ $changed_only == 0 ]]; then
-  profiles=$(find resources/zib resources/nl-core -maxdepth 1 -name "*.xml")
+  zib_resources=$(find resources/zib -maxdepth 1 -name "*.xml")
+  nlcore_resources=$(find resources/nl-core -maxdepth 1 -name "*.xml")
   terminology=$(find . -regex "\./resources/.*/terminology/[^/]*\.xml")
   examples=$(
     for file in examples/*;do
@@ -12,8 +13,10 @@ if [[ $changed_only == 0 ]]; then
     done
   )
 else
-  profiles=$(git diff --name-only --diff-filter=ACM origin/main -- resources/zib/*.xml resources/nl-core/*.xml)
-  profiles="$profiles "$(git ls-files --others -- resources/zib/*.xml resources/nl-core/*.xml)
+  zib_resources=$(git diff --name-only --diff-filter=ACM origin/main -- resources/zib/*.xml)
+  zib_resources="$zib_resources "$(git ls-files --others -- resources/zib/*.xml)
+  nlcore_resources=$(git diff --name-only --diff-filter=ACM origin/main -- resources/nl-core/*.xml)
+  nlcore_resources="$nlcore_resources "$(git ls-files --others -- resources/nl-core/*.xml)
   terminology=$(git diff --name-only --diff-filter=ACM origin/main -- resources/zib/terminology/*.xml resources/nl-core/terminology/*.xml)
   terminology="$terminology "$(git ls-files --others -- resources/zib/terminology/*.xml resources/nl-core/terminology/*.xml)
   examples=$(git diff --name-only --diff-filter=ACM origin/main -- examples)
@@ -24,15 +27,25 @@ fi
 zib_profiles=""
 zib_extensions=""
 nlcore_profiles=""
+nlcore_extensions=""
 other_profiles=""
-for file in $profiles; do
+for file in $zib_resources; do
   if [[ -f $file ]]; then
     if [[ $(basename $file) =~ ^zib- ]]; then
       zib_profiles="$zib_profiles $file"
     elif [[ $(basename $file) =~ ^ext-.*\.[A-Z] ]]; then
       zib_extensions="$zib_extensions $file"
-    elif [[ $(basename $file) =~ ^nl-core- ]]; then
+    else
+      other_profiles="$other_profiles $file"
+    fi
+  fi
+done
+for file in $nlcore_resources; do
+  if [[ -f $file ]]; then
+    if [[ $(basename $file) =~ ^nl-core- ]]; then
       nlcore_profiles="$nlcore_profiles $file"
+    elif [[ $(basename $file) =~ ^ext-.*\.[A-Z] ]]; then
+      nlcore_extensions="$nlcore_extensions $file"
     else
       other_profiles="$other_profiles $file"
     fi
@@ -56,6 +69,7 @@ done
 export zib_profiles
 export zib_extensions
 export nlcore_profiles
+export nlcore_extensions
 export other_profiles
 export conceptmaps
 export other_terminology

--- a/util/qaAutomation/mkprofilingig.sh
+++ b/util/qaAutomation/mkprofilingig.sh
@@ -1,8 +1,0 @@
-#/bin/bash
-
-# Create an "ig" with both the resources and the ProfilingGuidelines profiles
-mkdir ig
-cd ig
-ln -s ../resources
-ln -s ../qa/*.xml .
-cd ..


### PR DESCRIPTION
Hi Pieter,

I try to mitigate two types of errors by the QA tooling:

* "sd-pg-02: 'If mapping.map exists and the mapping is not implicit, short should exist'" for the nl-core profiles. I did this by moving the constraints from the general SD to the SD for zib-profiles.
* "StructureDefinition.purpose: minimum required = 1, but only found 0" for extension that are created in the nl-core folder. This is not solved yet. I think this should be adjusted in the validate yml file or something. Could you have a look?