### PR TITLE
zib-Payer

### DIFF
--- a/examples/nl-core-Payer-01.xml
+++ b/examples/nl-core-Payer-01.xml
@@ -1,0 +1,27 @@
+<Coverage xmlns="http://hl7.org/fhir">
+    <id value="nl-core-Payer-01"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer"/>
+    </meta>
+    <status value="cancelled"/>
+    <type>
+        <coding>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.101.5.1"/>
+            <code value="B"/>
+            <display value="Basis verzekerd"/>
+        </coding>
+    </type>
+    <subscriberId value="123456789"/>
+    <beneficiary>
+        <reference value="Patient/nl-core-patient-01"/>
+        <display value="Johan XXX_Helleman"/>
+    </beneficiary>
+    <period>
+        <start value="2018-01-01"/>
+        <end value="2019-01-31"/>
+    </period>
+    <payor>
+        <reference value="Organization/nl-core-Payer-Organization-01"/>
+        <display value="Menzis Zorgverzekeraar N.V."/>
+    </payor>
+</Coverage>

--- a/examples/nl-core-Payer-02.xml
+++ b/examples/nl-core-Payer-02.xml
@@ -1,0 +1,34 @@
+<Coverage xmlns="http://hl7.org/fhir">
+    <id value="nl-core-Payer-02"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer"/>
+    </meta>
+    <status value="cancelled"/>
+    <type>
+        <coding>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.101.5.1"/>
+            <code value="B"/>
+            <display value="Basis verzekerd"/>
+        </coding>
+    </type>
+    <subscriberId value="123456789"/>
+    <beneficiary>
+        <reference value="Patient/nl-core-patient-01"/>
+        <display value="Johan XXX_Helleman"/>
+    </beneficiary>
+    <payor>
+        <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation">
+            <extension url="bankName">
+                <valueString value="ING"/>
+            </extension>
+            <extension url="bankCode">
+                <valueString value="INGBNL2A"/>
+            </extension>
+            <extension url="accountNumber">
+                <valueString value="NL85INGB0001234567"/>
+            </extension>
+        </extension>
+        <reference value="Patient/nl-core-Payer-Patient-01"/>
+        <display value="Johan XXX_Helleman"/>
+    </payor>
+</Coverage>

--- a/examples/nl-core-Payer-03.xml
+++ b/examples/nl-core-Payer-03.xml
@@ -1,0 +1,27 @@
+<Coverage xmlns="http://hl7.org/fhir">
+    <id value="nl-core-Payer-03"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer"/>
+    </meta>
+    <status value="cancelled"/>
+    <type>
+        <coding>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.101.5.1"/>
+            <code value="B"/>
+            <display value="Basis verzekerd"/>
+        </coding>
+    </type>
+    <subscriberId value="123456789"/>
+    <beneficiary>
+        <reference value="Patient/nl-core-patient-01"/>
+        <display value="Johan XXX_Helleman"/>
+    </beneficiary>
+    <period>
+        <start value="2018-01-01"/>
+        <end value="2019-01-31"/>
+    </period>
+    <payor>
+        <reference value="Organization/nl-core-Payer-Random-Organization-01"/>
+        <display value="Random organisatie B.V."/>
+    </payor>
+</Coverage>

--- a/examples/nl-core-Payer-Organization-01.xml
+++ b/examples/nl-core-Payer-Organization-01.xml
@@ -1,0 +1,11 @@
+<Organization xmlns="http://hl7.org/fhir">
+    <id value="nl-core-Payer-Organization-01"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer-Organization"/>
+    </meta>
+    <identifier>
+        <system value="http://fhir.nl/fhir/NamingSystem/uzovi"/>
+        <value value="3332"/>
+    </identifier>
+    <name value="Menzis Zorgverzekeraar N.V."/>
+</Organization>

--- a/examples/nl-core-Payer-Patient-01.xml
+++ b/examples/nl-core-Payer-Patient-01.xml
@@ -1,0 +1,28 @@
+<Patient xmlns="http://hl7.org/fhir">
+    <id value="nl-core-Payer-Patient-01"/>
+    <meta>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+    </meta>
+    <identifier>
+        <use value="official"/>
+        <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
+        <value value="999911120"/>
+    </identifier>
+    <active value="true"/>
+    <name>
+        <extension url="http://hl7.org/fhir/StructureDefinition/humanname-assembly-order">
+            <valueCode value="NL4"/>
+        </extension>
+        <text value="Johan XXX_Helleman"/>
+        <family value="XXX_Helleman">
+            <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+                <valueString value="XXX_Helleman"/>
+            </extension>
+        </family>
+        <given value="Johan">
+            <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+                <valueCode value="CL"/>
+            </extension>
+        </given>
+    </name>
+</Patient>

--- a/examples/nl-core-Payer-Random-Organization-01.xml
+++ b/examples/nl-core-Payer-Random-Organization-01.xml
@@ -1,0 +1,4 @@
+<Organization xmlns="http://hl7.org/fhir">
+    <id value="nl-core-Payer-Random-Organization-01"/>
+    <name value="Random organisatie B.V."/>
+</Organization>

--- a/known-issues.yml
+++ b/known-issues.yml
@@ -35,6 +35,8 @@ zib-ContactPerson:
         reason: The cardinality mismatch between the zib (0..1) and FHIR (0..*) is explained by the presence of the HumanName.use element. A full name can be broken into parts using multiple instances of HumanName that have its own value for use. Documented in the profile too.
       - datatype: HumanName
         reason: A name in FHIR is represented using the HumanName datatype, not as a separate resource.
+      - short: NameInformation
+        reason: The concept PayerName from zib-Payer is also mapped on Patient.name. However, because this mapping is secondary to NameInformation, we exclude it from appearing in short.
     RelatedPerson.address:
       - datatype: Address
         reason: An address in FHIR is represented using the Address datatype, not as a separate resource.
@@ -160,6 +162,8 @@ zib-Patient:
         reason: The cardinality mismatch between the zib (0..1) and FHIR (0..*) is explained by the presence of the HumanName.use element. A full name can be broken into parts using multiple instances of HumanName that have its own value for use. Documented in the profile too.
       - datatype: HumanName
         reason: A name in FHIR is represented using the HumanName datatype, not as a separate resource.
+      - short: NameInformation
+        reason: The concept PayerName from zib-Payer is also mapped on Patient.name. However, because this mapping is secondary to NameInformation, we exclude it from appearing in short.
     Patient.telecom:
       - datatype: ContactPoint
         reason: ContactInformation in FHIR is represented using the ContactPoint datatype, not as a separate resource.
@@ -223,3 +227,29 @@ zib-Patient:
         reason: The mapping is placed on the extension and not on the value[x] because of the nature of this extension. The extension itself contains a valueCoding that gets the zibs value. This datatype matches the zib CD type.
       - cardinality: 0..*
         reason: Because of the nature of this extension the cardinality has a mismatch. Three zib concepts are mapped to this extension. Therefore the extension cannot be 0..1, but should be able to repeat.
+
+zib-Payer:
+  zib deviations:
+    Coverage.identifier:insurantNumber:
+      - datatype: Identifier
+        reason: The value of an Identifier has datatype string, which correspons with the string datatype of zib concept InsurantNumber.
+    Coverage.payor:payerPerson.extension:bankInformation:
+      - datatype: Extension
+        reason: The (complex) extension acts as a container for three sub-extensions that each contain a zib sub-concept.
+
+zib-Payer-Organization:
+  zib deviations:
+    Organization.telecom:
+      - datatype: ContactPoint
+        reason: ContactInformation in FHIR is represented using the ContactPoint datatype, not as a separate resource. Because the FHIR profile for ContactInformation consits of two parts the rootconcept of the ContactInformation is mapped on .telecom.
+    Organization.telecom:telephoneNumbers:
+      - datatype: ContactPoint
+        reason: See Organization.telecom
+    Organization.telecom:emailAddresses:
+      - datatype: ContactPoint
+        reason: See Organization.telecom
+    Organization.address:
+      - datatype: Address
+        reason: An address in FHIR is represented using the Address datatype, not as a separate resource.
+      - cardinality: 0..*
+        reason: The zib AddressInformation may be represented using multiple FHIR Address instances, hence the cardinality is wider.

--- a/resources/nl-core/nl-core-Payer-Organization.xml
+++ b/resources/nl-core/nl-core-Payer-Organization.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="nl-core-Payer-Organization" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer-Organization" />
+  <name value="NlcorePayerOrganization" />
+  <title value="nl core Payer Organization" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves." />
+  <purpose value="A derived profile from [zib-Payer-Organization](http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization) to provide a version better suited for implementation purposes. This profile augments the base profile with elements found in the various use cases that have adopted the zib." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Organization" />
+  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Organization">
+      <path value="Organization" />
+      <alias value="nl-core-Payer-Organization" />
+    </element>
+    <element id="Organization.telecom:telephoneNumbers">
+      <path value="Organization.telecom" />
+      <sliceName value="telephoneNumbers" />
+      <type>
+        <code value="ContactPoint" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-ContactInformation-TelephoneNumbers" />
+      </type>
+    </element>
+    <element id="Organization.telecom:emailAddresses">
+      <path value="Organization.telecom" />
+      <sliceName value="emailAddresses" />
+      <type>
+        <code value="ContactPoint" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-ContactInformation-EmailAddresses" />
+      </type>
+    </element>
+    <element id="Organization.address">
+      <path value="Organization.address" />
+      <type>
+        <code value="Address" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-AddressInformation" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/nl-core/nl-core-Payer.xml
+++ b/resources/nl-core/nl-core-Payer.xml
@@ -28,6 +28,14 @@
       <path value="Coverage" />
       <alias value="nl-core-Payer" />
     </element>
+    <element id="Coverage.beneficiary">
+      <path value="Coverage.beneficiary" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+    </element>
     <element id="Coverage.payor:payerPerson">
       <path value="Coverage.payor" />
       <sliceName value="payerPerson" />

--- a/resources/nl-core/nl-core-Payer.xml
+++ b/resources/nl-core/nl-core-Payer.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="nl-core-Payer" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer" />
+  <name value="NlcorePayer" />
+  <title value="nl core Payer" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves." />
+  <purpose value="A derived profile from [zib-Payer](http://nictiz.nl/fhir/StructureDefinition/zib-Payer) to provide a version better suited for implementation purposes. This profile augments the base profile with elements found in the various use cases that have adopted the zib." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Coverage" />
+  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Coverage">
+      <path value="Coverage" />
+      <alias value="nl-core-Payer" />
+    </element>
+    <element id="Coverage.payor:payerPerson">
+      <path value="Coverage.payor" />
+      <sliceName value="payerPerson" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-ContactPerson" />
+      </type>
+    </element>
+    <element id="Coverage.payor:insuranceCompany">
+      <path value="Coverage.payor" />
+      <sliceName value="insuranceCompany" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Payer-Organization" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib/ext-Payer.BankInformation.xml
+++ b/resources/zib/ext-Payer.BankInformation.xml
@@ -1,134 +1,135 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-    <id value="ext-Payer.BankInformation"/>
-    <url value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
-    <name value="ExtPayerBankInformation"/>
-    <title value="ext Payer.BankInformation"/>
-    <status value="draft"/>
-    <publisher value="Nictiz"/>
-    <contact>
-        <name value="Nictiz"/>
-        <telecom>
-            <system value="email"/>
-            <value value="info@nictiz.nl"/>
-            <use value="work"/>
-        </telecom>
-    </contact>
-    <purpose value="This extension represents the BankInformation concept of the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))."/>
-    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
-    <fhirVersion value="4.0.1"/>
-    <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN"/>
-        <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)"/>
-        <name value="zib Payer-v3.1.1(2020EN)"/>
-    </mapping>
-    <kind value="complex-type"/>
-    <abstract value="false"/>
-    <context>
-        <type value="element"/>
-        <expression value="Coverage.payor"/>
-    </context>
-    <type value="Extension"/>
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
-    <derivation value="constraint"/>
-    <differential>
-        <element id="Extension">
-            <path value="Extension"/>
+  <id value="ext-Payer.BankInformation" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation" />
+  <name value="ExtPayerBankInformation" />
+  <title value="ext Payer.BankInformation" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="This extension adds the concept BankInformation from the [zib Payer v3.1.1(2020)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN)) to the payor element of the Consent resource. The extention contains contains all data elements of the BankInformation concept." />
+  <purpose value="This extension represents the BankInformation concept of the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="zib-payer-v3.1.1-2020EN" />
+    <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)" />
+    <name value="zib Payer-v3.1.1(2020EN)" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="Coverage.payor" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension">
+      <path value="Extension" />
             <short value="BankInformation"/>
             <definition value="Container of the BankInformation concept. This container contains all data elements of the BankInformation concept."/>
             <alias value="Bankgegevens"/>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.4"/>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.4" />
                 <comment value="BankInformation"/>
-            </mapping>
-        </element>
-        <element id="Extension.extension">
-            <path value="Extension.extension"/>
-            <slicing>
-                <discriminator>
-                    <type value="value"/>
-                    <path value="url"/>
-                </discriminator>
-                <rules value="open"/>
-            </slicing>
-        </element>
-        <element id="Extension.extension:bankName">
-            <path value="Extension.extension"/>
-            <sliceName value="bankName"/>
-            <max value="1"/>
-        </element>
-        <element id="Extension.extension:bankName.url">
-            <path value="Extension.extension.url"/>
-            <fixedUri value="bankName"/>
-        </element>
-        <element id="Extension.extension:bankName.value[x]">
-            <path value="Extension.extension.value[x]"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension">
+      <path value="Extension.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Extension.extension:bankName">
+      <path value="Extension.extension" />
+      <sliceName value="bankName" />
+      <max value="1" />
+    </element>
+    <element id="Extension.extension:bankName.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="bankName" />
+    </element>
+    <element id="Extension.extension:bankName.value[x]">
+      <path value="Extension.extension.value[x]" />
             <short value="BankName"/>
             <definition value="Name of the financial organization."/>
             <alias value="BankNaam"/>
-            <type>
-                <code value="string"/>
-            </type>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.9"/>
+      <type>
+        <code value="string" />
+      </type>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.9" />
                 <comment value="BankName"/>
-            </mapping>
-        </element>
-        <element id="Extension.extension:bankCode">
-            <path value="Extension.extension"/>
-            <sliceName value="bankCode"/>
-            <max value="1"/>
-        </element>
-        <element id="Extension.extension:bankCode.url">
-            <path value="Extension.extension.url"/>
-            <fixedUri value="bankCode"/>
-        </element>
-        <element id="Extension.extension:bankCode.value[x]">
-            <path value="Extension.extension.value[x]"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension:bankCode">
+      <path value="Extension.extension" />
+      <sliceName value="bankCode" />
+      <max value="1" />
+    </element>
+    <element id="Extension.extension:bankCode.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="bankCode" />
+    </element>
+    <element id="Extension.extension:bankCode.value[x]">
+      <path value="Extension.extension.value[x]" />
             <short value="BankCode"/>
             <definition value="Code indicating the bank and branch. For European countries, this is the organization’s BIC or SWIFT code."/>
             <alias value="Bankcode"/>
-            <type>
-                <code value="string"/>
-            </type>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.10"/>
+      <type>
+        <code value="string" />
+      </type>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.10" />
                 <comment value="BankCode"/>
-            </mapping>
-        </element>
-        <element id="Extension.extension:accountNumber">
-            <path value="Extension.extension"/>
-            <sliceName value="accountNumber"/>
-            <max value="1"/>
-        </element>
-        <element id="Extension.extension:accountNumber.url">
-            <path value="Extension.extension.url"/>
-            <fixedUri value="accountNumber"/>
-        </element>
-        <element id="Extension.extension:accountNumber.value[x]">
-            <path value="Extension.extension.value[x]"/>
+      </mapping>
+    </element>
+    <element id="Extension.extension:accountNumber">
+      <path value="Extension.extension" />
+      <sliceName value="accountNumber" />
+      <max value="1" />
+    </element>
+    <element id="Extension.extension:accountNumber.url">
+      <path value="Extension.extension.url" />
+      <fixedUri value="accountNumber" />
+    </element>
+    <element id="Extension.extension:accountNumber.value[x]">
+      <path value="Extension.extension.value[x]" />
             <short value="AccountNumber"/>
             <definition value="The payer’s bank account number at the listed organization. For European countries, this is the IBAN."/>
             <alias value="Rekeningnummer"/>
-            <type>
-                <code value="string"/>
-            </type>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.11"/>
+      <type>
+        <code value="string" />
+      </type>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.11" />
                 <comment value="AccountNumber"/>
-            </mapping>
-        </element>
-        <element id="Extension.url">
-            <path value="Extension.url"/>
-            <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
-        </element>
-        <element id="Extension.value[x]">
-            <path value="Extension.value[x]"/>
-            <max value="0"/>
-        </element>
-    </differential>
+      </mapping>
+    </element>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <max value="0" />
+    </element>
+  </differential>
 </StructureDefinition>

--- a/resources/zib/ext-Payer.BankInformation.xml
+++ b/resources/zib/ext-Payer.BankInformation.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="ext-Payer.BankInformation"/>
+    <url value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
+    <name value="ExtPayerBankInformation"/>
+    <title value="ext Payer.BankInformation"/>
+    <status value="draft"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="email"/>
+            <value value="info@nictiz.nl"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <purpose value="This extension represents the BankInformation concept of the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))."/>
+    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN"/>
+        <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)"/>
+        <name value="zib Payer-v3.1.1(2020EN)"/>
+    </mapping>
+    <kind value="complex-type"/>
+    <abstract value="false"/>
+    <context>
+        <type value="element"/>
+        <expression value="Coverage.payor"/>
+    </context>
+    <type value="Extension"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Extension">
+            <path value="Extension"/>
+            <short value="BankInformation"/>
+            <definition value="Container of the BankInformation concept. This container contains all data elements of the BankInformation concept."/>
+            <alias value="Bankgegevens"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.4"/>
+                <comment value="BankInformation"/>
+            </mapping>
+        </element>
+        <element id="Extension.extension">
+            <path value="Extension.extension"/>
+            <slicing>
+                <discriminator>
+                    <type value="value"/>
+                    <path value="url"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+        </element>
+        <element id="Extension.extension:bankName">
+            <path value="Extension.extension"/>
+            <sliceName value="bankName"/>
+            <max value="1"/>
+        </element>
+        <element id="Extension.extension:bankName.url">
+            <path value="Extension.extension.url"/>
+            <fixedUri value="bankName"/>
+        </element>
+        <element id="Extension.extension:bankName.value[x]">
+            <path value="Extension.extension.value[x]"/>
+            <short value="BankName"/>
+            <definition value="Name of the financial organization."/>
+            <alias value="BankNaam"/>
+            <type>
+                <code value="string"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.9"/>
+                <comment value="BankName"/>
+            </mapping>
+        </element>
+        <element id="Extension.extension:bankCode">
+            <path value="Extension.extension"/>
+            <sliceName value="bankCode"/>
+            <max value="1"/>
+        </element>
+        <element id="Extension.extension:bankCode.url">
+            <path value="Extension.extension.url"/>
+            <fixedUri value="bankCode"/>
+        </element>
+        <element id="Extension.extension:bankCode.value[x]">
+            <path value="Extension.extension.value[x]"/>
+            <short value="BankCode"/>
+            <definition value="Code indicating the bank and branch. For European countries, this is the organization’s BIC or SWIFT code."/>
+            <alias value="Bankcode"/>
+            <type>
+                <code value="string"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.10"/>
+                <comment value="BankCode"/>
+            </mapping>
+        </element>
+        <element id="Extension.extension:accountNumber">
+            <path value="Extension.extension"/>
+            <sliceName value="accountNumber"/>
+            <max value="1"/>
+        </element>
+        <element id="Extension.extension:accountNumber.url">
+            <path value="Extension.extension.url"/>
+            <fixedUri value="accountNumber"/>
+        </element>
+        <element id="Extension.extension:accountNumber.value[x]">
+            <path value="Extension.extension.value[x]"/>
+            <short value="AccountNumber"/>
+            <definition value="The payer’s bank account number at the listed organization. For European countries, this is the IBAN."/>
+            <alias value="Rekeningnummer"/>
+            <type>
+                <code value="string"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.11"/>
+                <comment value="AccountNumber"/>
+            </mapping>
+        </element>
+        <element id="Extension.url">
+            <path value="Extension.url"/>
+            <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
+        </element>
+        <element id="Extension.value[x]">
+            <path value="Extension.value[x]"/>
+            <max value="0"/>
+        </element>
+    </differential>
+</StructureDefinition>

--- a/resources/zib/terminology/VerzekeringssoortCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000.xml
+++ b/resources/zib/terminology/VerzekeringssoortCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000.xml
@@ -1,0 +1,137 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000"/>
+    <meta>
+        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+    </meta>
+    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+        <valuePeriod>
+            <start value="2020-09-01T00:00:00+02:00"/>
+        </valuePeriod>
+    </extension>
+    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000"/>
+    <identifier>
+        <use value="official"/>
+        <system value="http://art-decor.org/ns/oids/vs"/>
+        <value value="2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1"/>
+    </identifier>
+    <version value="2020-09-01T00:00:00"/>
+    <name value="VerzekeringssoortCodelijst"/>
+    <title value="VerzekeringssoortCodelijst"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Registratie aan de bron"/>
+    <contact>
+        <name value="Registratie aan de bron"/>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.registratieaandebron.nl"/>
+        </telecom>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.zibs.nl"/>
+        </telecom>
+    </contact>
+    <description value="VerzekeringssoortCodelijst"/>
+    <immutable value="false"/>
+    <compose>
+        <include>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.101.5.1"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Basis verzekerd"/>
+                </extension>
+                <code value="B"/>
+                <display value="Basis"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Basis"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Aanvullend verzekerd"/>
+                </extension>
+                <code value="A"/>
+                <display value="Aanvullend verzekerd"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Aanvullend verzekerd"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Basisverzekering vanuit AWBZ (tegenwoordig uit Wet Langdurige Zorg)"/>
+                </extension>
+                <code value="BZ"/>
+                <display value="Basisverzekering vanuit AWBZ"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Basisverzekering vanuit AWBZ"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Een basisverzekering die geen onderdeel uitmaakt van de ZVW of AWBZ (bijvoorbeeld voor expats in het buitenland)."/>
+                </extension>
+                <code value="H"/>
+                <display value="Hoofdverzekering"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Hoofdverzekering"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Tandverzekering"/>
+                </extension>
+                <code value="T"/>
+                <display value="Tandverzekering (los)"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Tandverzekering (los)"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Aanvullend + tand"/>
+                </extension>
+                <code value="AT"/>
+                <display value="Aanvullend + tand"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Aanvullend + tand"/>
+                </designation>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/zib/zib-ContactPerson.xml
+++ b/resources/zib/zib-ContactPerson.xml
@@ -108,6 +108,7 @@
       <definition value="Full name of the contact." />
       <comment value="The cardinality mismatch between the zib (0..1) and FHIR (0..*) is explained by the presence of the HumanName.use element. A full name can be broken into parts using multiple instances of HumanName that have its own value for use." />
       <alias value="Naamgegevens" />
+      <alias value="BetalerNaam" />
       <type>
         <code value="HumanName" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-NameInformation" />

--- a/resources/zib/zib-ContactPerson.xml
+++ b/resources/zib/zib-ContactPerson.xml
@@ -28,6 +28,11 @@
     <uri value="https://zibs.nl/wiki/ContactInformation-v1.2(2020EN)" />
     <name value="zib ContactInformation-v1.2(2020EN)" />
   </mapping>
+  <mapping>
+    <identity value="zib-payer-v3.1.1-2020EN" />
+    <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)" />
+    <name value="zib Payer-v3.1.1(2020EN)" />
+  </mapping>
   <kind value="resource" />
   <abstract value="true" />
   <type value="RelatedPerson" />
@@ -112,6 +117,11 @@
         <map value="NL-CM:3.1.4" />
         <comment value="NameInformation" />
       </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.5" />
+        <comment value="PayerName" />
+      </mapping>
     </element>
     <element id="RelatedPerson.telecom">
       <path value="RelatedPerson.telecom" />
@@ -134,6 +144,11 @@
       <mapping>
         <identity value="zib-contactinformation-v1.2-2020EN" />
         <map value="NL-CM:20.6.1" />
+        <comment value="ContactInformation" />
+      </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.12" />
         <comment value="ContactInformation" />
       </mapping>
     </element>
@@ -165,6 +180,11 @@
       <mapping>
         <identity value="zib-contactperson-v3.4-2020EN" />
         <map value="NL-CM:3.1.5" />
+        <comment value="AddressInformation" />
+      </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.17" />
         <comment value="AddressInformation" />
       </mapping>
     </element>

--- a/resources/zib/zib-Patient.xml
+++ b/resources/zib/zib-Patient.xml
@@ -50,6 +50,11 @@
     <uri value="https://zibs.nl/wiki/ContactPerson-v3.4(2020EN)" />
     <name value="zib ContactPerson-v3.4(2020EN)" />
   </mapping>
+  <mapping>
+    <identity value="zib-payer-v3.1.1-2020EN" />
+    <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)" />
+    <name value="zib Payer-v3.1.1(2020EN)" />
+  </mapping>
   <kind value="resource" />
   <abstract value="true" />
   <type value="Patient" />
@@ -155,6 +160,11 @@
         <map value="NL-CM:0.1.6" />
         <comment value="NameInformation" />
       </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.5" />
+        <comment value="PayerName" />
+      </mapping>
     </element>
     <element id="Patient.telecom">
       <path value="Patient.telecom" />
@@ -177,6 +187,11 @@
       <mapping>
         <identity value="zib-contactinformation-v1.2-2020EN" />
         <map value="NL-CM:20.6.1" />
+        <comment value="ContactInformation" />
+      </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.12" />
         <comment value="ContactInformation" />
       </mapping>
     </element>
@@ -321,6 +336,11 @@
       <mapping>
         <identity value="zib-patient-v3.2-2020EN" />
         <map value="NL-CM:0.1.4" />
+        <comment value="AddressInformation" />
+      </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.17" />
         <comment value="AddressInformation" />
       </mapping>
     </element>

--- a/resources/zib/zib-Patient.xml
+++ b/resources/zib/zib-Patient.xml
@@ -151,6 +151,7 @@
       <definition value="Patient's full name.&#xD;&#xA;The cardinality differs from the zib to allow including several name elements with a different name.use each." />
       <comment value="The cardinality mismatch between the zib (0..1) and FHIR (0..*) is explained by the presence of the HumanName.use element. A full name can be broken into parts using multiple instances of HumanName that have its own value for use." />
       <alias value="Naamgegevens" />
+      <alias value="BetalerNaam" />
       <type>
         <code value="HumanName" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-NameInformation" />

--- a/resources/zib/zib-Payer-Organization.xml
+++ b/resources/zib/zib-Payer-Organization.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="zib-Payer-Organization"/>
+    <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization"/>
+    <name value="ZibPayerOrganization"/>
+    <title value="zib Payer Organization"/>
+    <status value="draft"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="email"/>
+            <value value="info@nictiz.nl"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves."/>
+    <purpose value="This Organization resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) ]()."/>
+    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN"/>
+        <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)"/>
+        <name value="zib Payer-v3.1.1(2020EN)"/>
+    </mapping>
+    <kind value="resource"/>
+    <abstract value="true"/>
+    <type value="Organization"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Organization"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Organization">
+            <path value="Organization"/>
+            <short value="InsuranceCompany"/>
+            <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept."/>
+            <alias value="Verzekeraar"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.3"/>
+                <comment value="InsuranceCompany"/>
+            </mapping>
+        </element>
+        <element id="Organization.identifier">
+            <path value="Organization.identifier"/>
+            <slicing>
+                <discriminator>
+                    <type value="value"/>
+                    <path value="$this"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+        </element>
+        <element id="Organization.identifier:uzovi">
+            <path value="Organization.identifier"/>
+            <sliceName value="uzovi"/>
+            <short value="IdentificationNumber"/>
+            <definition value="Unique healthcare insurance company identification (the UZOVI number)."/>
+            <alias value="IdentificatieNummer"/>
+            <max value="1"/>
+            <patternIdentifier>
+                <system value="http://fhir.nl/fhir/NamingSystem/uzovi"/>
+            </patternIdentifier>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.7"/>
+                <comment value="IdentificationNumber"/>
+            </mapping>
+        </element>
+        <element id="Organization.name">
+            <path value="Organization.name"/>
+            <short value="OrganizationName"/>
+            <definition value="Full, official name of the healthcare insurance company. If the UZOVI number is entered as an identification number, this will be the name as listed in the UZOVI register and the name which is returned in the Check for Right to Insurance (COV)."/>
+            <alias value="OrganisatieNaam"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.16"/>
+                <comment value="OrganizationName"/>
+            </mapping>
+        </element>
+        <element id="Organization.telecom">
+            <path value="Organization.telecom"/>
+            <slicing>
+                <discriminator>
+                    <type value="profile"/>
+                    <path value="$this"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+            <short value="ContactInformation"/>
+            <definition value="The payer’s telephone number and/or e-mail address."/>
+            <alias value="Contactgegevens"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.12"/>
+                <comment value="ContactInformation"/>
+            </mapping>
+        </element>
+        <element id="Organization.telecom:telephoneNumbers">
+            <path value="Organization.telecom"/>
+            <sliceName value="telephoneNumbers"/>
+            <type>
+                <code value="ContactPoint"/>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactInformation-TelephoneNumbers"/>
+            </type>
+        </element>
+        <element id="Organization.telecom:emailAddresses">
+            <path value="Organization.telecom"/>
+            <sliceName value="emailAddresses"/>
+            <type>
+                <code value="ContactPoint"/>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactInformation-EmailAddresses"/>
+            </type>
+        </element>
+        <element id="Organization.address">
+            <path value="Organization.address"/>
+            <short value="AddressInformation"/>
+            <definition value="The payer’s address information."/>
+            <alias value="Adresgegevens"/>
+            <type>
+                <code value="Address"/>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.17"/>
+                <comment value="AddressInformation"/>
+            </mapping>
+        </element>
+    </differential>
+</StructureDefinition>

--- a/resources/zib/zib-Payer-Organization.xml
+++ b/resources/zib/zib-Payer-Organization.xml
@@ -33,6 +33,7 @@
             <path value="Organization"/>
             <short value="InsuranceCompany"/>
             <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept."/>
+            <comment value="The zib Payer is mapped to this Organization profile and a profile on Coverage (&amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-Payer&amp;gt;). The Coverage profile acts as the focal resource of Payer. This profile represents only the InsuranceCompany concept of the zib."/>
             <alias value="Verzekeraar"/>
             <mapping>
                 <identity value="zib-payer-v3.1.1-2020EN"/>

--- a/resources/zib/zib-Payer.xml
+++ b/resources/zib/zib-Payer.xml
@@ -1,167 +1,188 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-    <id value="zib-Payer"/>
-    <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer"/>
-    <name value="ZibPayer"/>
-    <title value="zib Payer"/>
-    <status value="draft"/>
-    <publisher value="Nictiz"/>
-    <contact>
-        <name value="Nictiz"/>
-        <telecom>
-            <system value="email"/>
-            <value value="info@nictiz.nl"/>
-            <use value="work"/>
-        </telecom>
-    </contact>
-    <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves."/>
-    <purpose value="This Coverage resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer-v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))."/>
-    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
-    <fhirVersion value="4.0.1"/>
-    <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN"/>
-        <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)"/>
-        <name value="zib Payer-v3.1.1(2020EN)"/>
-    </mapping>
-    <kind value="resource"/>
-    <abstract value="true"/>
-    <type value="Coverage"/>
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Coverage"/>
-    <derivation value="constraint"/>
-    <differential>
-        <element id="Coverage">
-            <path value="Coverage"/>
-            <short value="Payer / Insurance"/>
-            <definition value="* Root concept of the Payer information model. This root concept contains all data elements of the Payer information model.&#xD;&#xA;* Container of the Insurance concept. This container contains all data elements of the Insurance concept."/>
-            <comment value="The zib Payer is mapped to this Coverage profile and a profile on Organization (&amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization&amp;gt;). This Coverage profile acts as the focal resource of Payer, although Coverage is more associated with the Insurance container of the zib then with Payer as a whole. Nevertheless, the Coverage resource acts as an overarching resource that references the various resources that represent PayerPerson or InsuranceCompany and adds details like BankInformation. For the InsuranceCompany concept, the profile on Organization is used which is referenced using the `payor` element."/>
-            <alias value="Betaler"/>
-            <alias value="Verzekering"/>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.1"/>
-                <comment value="Payer"/>
-            </mapping>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.8"/>
-                <comment value="Insurance"/>
-            </mapping>
-        </element>
-        <element id="Coverage.identifier">
-            <path value="Coverage.identifier"/>
-            <short value="InsurantNumber"/>
-            <definition value="Number under which the insured person is registered at the insurance company This item maps the ‘Identification number of the card’ on EHIC field 8"/>
-            <alias value="VerzekerdeNummer"/>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.6"/>
-                <comment value="InsurantNumber"/>
-            </mapping>
-        </element>
-        <element id="Coverage.type">
-            <path value="Coverage.type"/>
-            <short value="InsuranceType"/>
-            <definition value="Type of insurance policy. Codes as returned in the Check for Right to Insurance"/>
-            <alias value="Verzekeringssoort"/>
-            <binding>
-                <strength value="required"/>
-                <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000"/>
-            </binding>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.15"/>
-                <comment value="InsuranceType"/>
-            </mapping>
-        </element>
-        <element id="Coverage.period.start">
-            <path value="Coverage.period.start"/>
-            <short value="StartDateTime"/>
-            <definition value="Date from which the insurance policy coverage applies."/>
-            <alias value="BeginDatumTijd"/>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.13"/>
-                <comment value="StartDateTime"/>
-            </mapping>
-        </element>
-        <element id="Coverage.period.end">
-            <path value="Coverage.period.end"/>
-            <short value="EndDateTime"/>
-            <definition value="Date until which the insurance policy coverage applies. This item maps the ‘Expiry date’ on EHIC field 9."/>
-            <alias value="EindDatumTijd"/>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.14"/>
-                <comment value="EndDateTime"/>
-            </mapping>
-        </element>
-        <element id="Coverage.payor">
-            <path value="Coverage.payor"/>
-            <slicing>
-                <discriminator>
-                    <type value="profile"/>
-                    <path value="resolve()"/>
-                </discriminator>
-                <rules value="open"/>
-            </slicing>
-            <max value="1"/>
-        </element>
-        <element id="Coverage.payor:payerPerson">
-            <path value="Coverage.payor"/>
-            <sliceName value="payerPerson"/>
-            <short value="PayerPerson"/>
-            <definition value="Container of the PayerPerson concept. This container contains all data elements of the PayerPerson concept.In this a person is a natural person or a juridical person, such as an organization, municipality, etc."/>
-            <comment value="If the resource referenced is conformant to one of the target zib profiles, these profiles provide a mapping to the relevant zib Payer concepts. If it is not of conformant to one of these zib profiles, it SHALL have at least the following FHIR elements filled to be compliant with the subsequent zib Payer concepts:&#xD;&#xA;* `name.text` - PayerPerson::PayerName (NL-CM:1.1.5)&#xD;&#xA;* `address` - AddressInformation (NL-CM:1.1.17)&#xD;&#xA;* `telecom` - ContactInformation (NL-CM:1.1.12)"/>
-            <alias value="BetalerPersoon"/>
-            <max value="1"/>
-            <type>
-                <code value="Reference"/>
-                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
-                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
-                <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
-                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient"/>
-                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson"/>
-            </type>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.2"/>
-                <comment value="PayerPerson"/>
-            </mapping>
-        </element>
-        <element id="Coverage.payor:payerPerson.extension">
-            <path value="Coverage.payor.extension"/>
-            <slicing>
-                <discriminator>
-                    <type value="value"/>
-                    <path value="url"/>
-                </discriminator>
-                <rules value="open"/>
-            </slicing>
-        </element>
-        <element id="Coverage.payor:payerPerson.extension:bankInformation">
-            <path value="Coverage.payor.extension"/>
-            <sliceName value="bankInformation"/>
-            <type>
-                <code value="Extension"/>
-                <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
-            </type>
-        </element>
-        <element id="Coverage.payor:insuranceCompany">
-            <path value="Coverage.payor"/>
-            <sliceName value="insuranceCompany"/>
-            <short value="InsuranceCompany"/>
-            <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept."/>
-            <alias value="Verzekeraar"/>
-            <max value="1"/>
-            <type>
-                <code value="Reference"/>
-                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization"/>
-            </type>
-            <mapping>
-                <identity value="zib-payer-v3.1.1-2020EN"/>
-                <map value="NL-CM:1.1.3"/>
-                <comment value="InsuranceCompany"/>
-            </mapping>
-        </element>
-    </differential>
+  <id value="zib-Payer" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer" />
+  <name value="ZibPayer" />
+  <title value="zib Payer" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves." />
+  <purpose value="This Coverage resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer-v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="zib-payer-v3.1.1-2020EN" />
+    <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)" />
+    <name value="zib Payer-v3.1.1(2020EN)" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="true" />
+  <type value="Coverage" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Coverage" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Coverage">
+      <path value="Coverage" />
+      <short value="Payer / Insurance" />
+      <definition value="* Root concept of the Payer information model. This root concept contains all data elements of the Payer information model.&#xD;&#xA;* Container of the Insurance concept. This container contains all data elements of the Insurance concept." />
+      <comment value="The zib Payer is mapped to this Coverage profile and a profile on Organization (&amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization&amp;gt;). This Coverage profile acts as the focal resource of Payer, although Coverage is more associated with the Insurance container of the zib then with Payer as a whole. Nevertheless, the Coverage resource acts as an overarching resource that references the various resources that represent PayerPerson or InsuranceCompany and adds details like BankInformation. For the InsuranceCompany concept, the profile on Organization is used which is referenced using the `payor` element." />
+      <alias value="Betaler" />
+      <alias value="Verzekering" />
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.1" />
+        <comment value="Payer" />
+      </mapping>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.8" />
+        <comment value="Insurance" />
+      </mapping>
+    </element>
+    <element id="Coverage.identifier">
+      <path value="Coverage.identifier" />
+      <slicing>
+        <discriminator>
+          <type value="pattern" />
+          <path value="type" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Coverage.identifier:insurantNumber">
+      <path value="Coverage.identifier" />
+      <sliceName value="insurantNumber" />
+      <short value="InsurantNumber" />
+      <definition value="Number under which the insured person is registered at the insurance company. This item maps the ‘Identification number of the card’ on EHIC field 8" />
+      <comment value="The zib defines InsurantNumber as mapping &quot;the ‘Identification number of the card’ on EHIC field 8&quot;. Some developments on mapping EHIC to FHIR are ongoing, but no Identifier.system has been defined yet. For this reason, only a mapping on `type` code 'SN' has been made." />
+      <alias value="VerzekerdeNummer" />
+      <max value="1" />
+      <patternIdentifier>
+        <type>
+          <coding>
+            <system value="http://terminology.hl7.org/CodeSystem/v2-0203" />
+            <code value="SN" />
+          </coding>
+        </type>
+      </patternIdentifier>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.6" />
+        <comment value="InsurantNumber" />
+      </mapping>
+    </element>
+    <element id="Coverage.type">
+      <path value="Coverage.type" />
+      <short value="InsuranceType" />
+      <definition value="Type of insurance policy. Codes as returned in the Check for Right to Insurance" />
+      <alias value="Verzekeringssoort" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000" />
+      </binding>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.15" />
+        <comment value="InsuranceType" />
+      </mapping>
+    </element>
+    <element id="Coverage.period.start">
+      <path value="Coverage.period.start" />
+      <short value="StartDateTime" />
+      <definition value="Date from which the insurance policy coverage applies." />
+      <alias value="BeginDatumTijd" />
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.13" />
+        <comment value="StartDateTime" />
+      </mapping>
+    </element>
+    <element id="Coverage.period.end">
+      <path value="Coverage.period.end" />
+      <short value="EndDateTime" />
+      <definition value="Date until which the insurance policy coverage applies. This item maps the ‘Expiry date’ on EHIC field 9." />
+      <alias value="EindDatumTijd" />
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.14" />
+        <comment value="EndDateTime" />
+      </mapping>
+    </element>
+    <element id="Coverage.payor">
+      <path value="Coverage.payor" />
+      <slicing>
+        <discriminator>
+          <type value="profile" />
+          <path value="resolve()" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <max value="1" />
+    </element>
+    <element id="Coverage.payor:payerPerson">
+      <path value="Coverage.payor" />
+      <sliceName value="payerPerson" />
+      <short value="PayerPerson" />
+      <definition value="Container of the PayerPerson concept. This container contains all data elements of the PayerPerson concept.In this a person is a natural person or a juridical person, such as an organization, municipality, etc." />
+      <comment value="If the resource referenced is conformant to one of the target zib profiles, these profiles provide a mapping to the relevant zib Payer concepts. If it is not of conformant to one of these zib profiles, it SHALL have at least the following FHIR elements filled to be compliant with the subsequent zib Payer concepts:&#xD;&#xA;* `name.text` - PayerPerson::PayerName (NL-CM:1.1.5)&#xD;&#xA;* `address` - AddressInformation (NL-CM:1.1.17)&#xD;&#xA;* `telecom` - ContactInformation (NL-CM:1.1.12)" />
+      <alias value="BetalerPersoon" />
+      <max value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson" />
+      </type>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.2" />
+        <comment value="PayerPerson" />
+      </mapping>
+    </element>
+    <element id="Coverage.payor:payerPerson.extension">
+      <path value="Coverage.payor.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Coverage.payor:payerPerson.extension:bankInformation">
+      <path value="Coverage.payor.extension" />
+      <sliceName value="bankInformation" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation" />
+      </type>
+    </element>
+    <element id="Coverage.payor:insuranceCompany">
+      <path value="Coverage.payor" />
+      <sliceName value="insuranceCompany" />
+      <short value="InsuranceCompany" />
+      <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept." />
+      <alias value="Verzekeraar" />
+      <max value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization" />
+      </type>
+      <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN" />
+        <map value="NL-CM:1.1.3" />
+        <comment value="InsuranceCompany" />
+      </mapping>
+    </element>
+  </differential>
 </StructureDefinition>

--- a/resources/zib/zib-Payer.xml
+++ b/resources/zib/zib-Payer.xml
@@ -47,6 +47,20 @@
                 <comment value="Insurance"/>
             </mapping>
         </element>
+        <element id="Coverage.status">
+            <path value="Coverage.status" />
+            <comment value="Sending systems that don't record an explicit status can use the following guidance to infer a value from the zib:&#xD;&#xA;&#xD;&#xA;* EndDateTime present:&#xD;&#xA;    * and in the future: _active_&#xD;&#xA;    * and in the past: _cancelled_&#xD;&#xA;* EndDateTime absent: (not zib compliant because of zib cardinality 1..1)&#xD;&#xA;    * StartDateTime present: _active_&#xD;&#xA;    * StartDateTime absent: _draft_" />
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.13"/>
+                <comment value="StartDateTime (implicit, main mapping is on Coverage.period.start)"/>
+            </mapping>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.14"/>
+                <comment value="EndDateTime (implicit, main mapping is on Coverage.period.start)"/>
+            </mapping>
+        </element>
         <element id="Coverage.type">
             <path value="Coverage.type"/>
             <short value="InsuranceType"/>
@@ -72,6 +86,14 @@
                 <map value="NL-CM:1.1.6"/>
                 <comment value="InsurantNumber"/>
             </mapping>
+        </element>
+        <element id="Coverage.beneficiary">
+            <path value="Coverage.beneficiary"/>
+            <type>
+                <code value="Reference"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient"/>
+            </type>
         </element>
         <element id="Coverage.period.start">
             <path value="Coverage.period.start"/>

--- a/resources/zib/zib-Payer.xml
+++ b/resources/zib/zib-Payer.xml
@@ -1,188 +1,167 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-  <id value="zib-Payer" />
-  <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer" />
-  <name value="ZibPayer" />
-  <title value="zib Payer" />
-  <status value="draft" />
-  <publisher value="Nictiz" />
-  <contact>
-    <name value="Nictiz" />
-    <telecom>
-      <system value="email" />
-      <value value="info@nictiz.nl" />
-      <use value="work" />
-    </telecom>
-  </contact>
-  <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves." />
-  <purpose value="This Coverage resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer-v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))." />
-  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
-  <fhirVersion value="4.0.1" />
-  <mapping>
-    <identity value="zib-payer-v3.1.1-2020EN" />
-    <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)" />
-    <name value="zib Payer-v3.1.1(2020EN)" />
-  </mapping>
-  <kind value="resource" />
-  <abstract value="true" />
-  <type value="Coverage" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Coverage" />
-  <derivation value="constraint" />
-  <differential>
-    <element id="Coverage">
-      <path value="Coverage" />
-      <short value="Payer / Insurance" />
-      <definition value="* Root concept of the Payer information model. This root concept contains all data elements of the Payer information model.&#xD;&#xA;* Container of the Insurance concept. This container contains all data elements of the Insurance concept." />
-      <comment value="The zib Payer is mapped to this Coverage profile and a profile on Organization (&amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization&amp;gt;). This Coverage profile acts as the focal resource of Payer, although Coverage is more associated with the Insurance container of the zib then with Payer as a whole. Nevertheless, the Coverage resource acts as an overarching resource that references the various resources that represent PayerPerson or InsuranceCompany and adds details like BankInformation. For the InsuranceCompany concept, the profile on Organization is used which is referenced using the `payor` element." />
-      <alias value="Betaler" />
-      <alias value="Verzekering" />
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.1" />
-        <comment value="Payer" />
-      </mapping>
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.8" />
-        <comment value="Insurance" />
-      </mapping>
-    </element>
-    <element id="Coverage.identifier">
-      <path value="Coverage.identifier" />
-      <slicing>
-        <discriminator>
-          <type value="pattern" />
-          <path value="type" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Coverage.identifier:insurantNumber">
-      <path value="Coverage.identifier" />
-      <sliceName value="insurantNumber" />
-      <short value="InsurantNumber" />
-      <definition value="Number under which the insured person is registered at the insurance company. This item maps the ‘Identification number of the card’ on EHIC field 8" />
-      <comment value="The zib defines InsurantNumber as mapping &quot;the ‘Identification number of the card’ on EHIC field 8&quot;. Some developments on mapping EHIC to FHIR are ongoing, but no Identifier.system has been defined yet. For this reason, only a mapping on `type` code 'SN' has been made." />
-      <alias value="VerzekerdeNummer" />
-      <max value="1" />
-      <patternIdentifier>
-        <type>
-          <coding>
-            <system value="http://terminology.hl7.org/CodeSystem/v2-0203" />
-            <code value="SN" />
-          </coding>
-        </type>
-      </patternIdentifier>
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.6" />
-        <comment value="InsurantNumber" />
-      </mapping>
-    </element>
-    <element id="Coverage.type">
-      <path value="Coverage.type" />
-      <short value="InsuranceType" />
-      <definition value="Type of insurance policy. Codes as returned in the Check for Right to Insurance" />
-      <alias value="Verzekeringssoort" />
-      <binding>
-        <strength value="required" />
-        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000" />
-      </binding>
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.15" />
-        <comment value="InsuranceType" />
-      </mapping>
-    </element>
-    <element id="Coverage.period.start">
-      <path value="Coverage.period.start" />
-      <short value="StartDateTime" />
-      <definition value="Date from which the insurance policy coverage applies." />
-      <alias value="BeginDatumTijd" />
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.13" />
-        <comment value="StartDateTime" />
-      </mapping>
-    </element>
-    <element id="Coverage.period.end">
-      <path value="Coverage.period.end" />
-      <short value="EndDateTime" />
-      <definition value="Date until which the insurance policy coverage applies. This item maps the ‘Expiry date’ on EHIC field 9." />
-      <alias value="EindDatumTijd" />
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.14" />
-        <comment value="EndDateTime" />
-      </mapping>
-    </element>
-    <element id="Coverage.payor">
-      <path value="Coverage.payor" />
-      <slicing>
-        <discriminator>
-          <type value="profile" />
-          <path value="resolve()" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <max value="1" />
-    </element>
-    <element id="Coverage.payor:payerPerson">
-      <path value="Coverage.payor" />
-      <sliceName value="payerPerson" />
-      <short value="PayerPerson" />
-      <definition value="Container of the PayerPerson concept. This container contains all data elements of the PayerPerson concept.In this a person is a natural person or a juridical person, such as an organization, municipality, etc." />
-      <comment value="If the resource referenced is conformant to one of the target zib profiles, these profiles provide a mapping to the relevant zib Payer concepts. If it is not of conformant to one of these zib profiles, it SHALL have at least the following FHIR elements filled to be compliant with the subsequent zib Payer concepts:&#xD;&#xA;* `name.text` - PayerPerson::PayerName (NL-CM:1.1.5)&#xD;&#xA;* `address` - AddressInformation (NL-CM:1.1.17)&#xD;&#xA;* `telecom` - ContactInformation (NL-CM:1.1.12)" />
-      <alias value="BetalerPersoon" />
-      <max value="1" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson" />
-      </type>
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.2" />
-        <comment value="PayerPerson" />
-      </mapping>
-    </element>
-    <element id="Coverage.payor:payerPerson.extension">
-      <path value="Coverage.payor.extension" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="url" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Coverage.payor:payerPerson.extension:bankInformation">
-      <path value="Coverage.payor.extension" />
-      <sliceName value="bankInformation" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation" />
-      </type>
-    </element>
-    <element id="Coverage.payor:insuranceCompany">
-      <path value="Coverage.payor" />
-      <sliceName value="insuranceCompany" />
-      <short value="InsuranceCompany" />
-      <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept." />
-      <alias value="Verzekeraar" />
-      <max value="1" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization" />
-      </type>
-      <mapping>
-        <identity value="zib-payer-v3.1.1-2020EN" />
-        <map value="NL-CM:1.1.3" />
-        <comment value="InsuranceCompany" />
-      </mapping>
-    </element>
-  </differential>
+    <id value="zib-Payer"/>
+    <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer"/>
+    <name value="ZibPayer"/>
+    <title value="zib Payer"/>
+    <status value="draft"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="email"/>
+            <value value="info@nictiz.nl"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves."/>
+    <purpose value="This Coverage resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer-v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))."/>
+    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN"/>
+        <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)"/>
+        <name value="zib Payer-v3.1.1(2020EN)"/>
+    </mapping>
+    <kind value="resource"/>
+    <abstract value="true"/>
+    <type value="Coverage"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Coverage"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Coverage">
+            <path value="Coverage"/>
+            <short value="Payer / Insurance"/>
+            <definition value="* Root concept of the Payer information model. This root concept contains all data elements of the Payer information model.&#xD;&#xA;* Container of the Insurance concept. This container contains all data elements of the Insurance concept."/>
+            <comment value="The zib Payer is mapped to this Coverage profile and a profile on Organization (&amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization&amp;gt;). This Coverage profile acts as the focal resource of Payer, although Coverage is more associated with the Insurance container of the zib then with Payer as a whole. Nevertheless, the Coverage resource acts as an overarching resource that references the various resources that represent PayerPerson or InsuranceCompany and adds details like BankInformation. For the InsuranceCompany concept, the profile on Organization is used which is referenced using the `payor` element."/>
+            <alias value="Betaler"/>
+            <alias value="Verzekering"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.1"/>
+                <comment value="Payer"/>
+            </mapping>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.8"/>
+                <comment value="Insurance"/>
+            </mapping>
+        </element>
+        <element id="Coverage.type">
+            <path value="Coverage.type"/>
+            <short value="InsuranceType"/>
+            <definition value="Type of insurance policy. Codes as returned in the Check for Right to Insurance"/>
+            <alias value="Verzekeringssoort"/>
+            <binding>
+                <strength value="required"/>
+                <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000"/>
+            </binding>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.15"/>
+                <comment value="InsuranceType"/>
+            </mapping>
+        </element>
+        <element id="Coverage.subscriberId">
+            <path value="Coverage.subscriberId"/>
+            <short value="InsurantNumber"/>
+            <definition value="Number under which the insured person is registered at the insurance company This item maps the ‘Identification number of the card’ on EHIC field 8&#xA;                        "/>
+            <alias value="VerzekerdeNummer"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.6"/>
+                <comment value="InsurantNumber"/>
+            </mapping>
+        </element>
+        <element id="Coverage.period.start">
+            <path value="Coverage.period.start"/>
+            <short value="StartDateTime"/>
+            <definition value="Date from which the insurance policy coverage applies."/>
+            <alias value="BeginDatumTijd"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.13"/>
+                <comment value="StartDateTime"/>
+            </mapping>
+        </element>
+        <element id="Coverage.period.end">
+            <path value="Coverage.period.end"/>
+            <short value="EndDateTime"/>
+            <definition value="Date until which the insurance policy coverage applies. This item maps the ‘Expiry date’ on EHIC field 9."/>
+            <alias value="EindDatumTijd"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.14"/>
+                <comment value="EndDateTime"/>
+            </mapping>
+        </element>
+        <element id="Coverage.payor">
+            <path value="Coverage.payor"/>
+            <slicing>
+                <discriminator>
+                    <type value="profile"/>
+                    <path value="resolve()"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+            <max value="1"/>
+        </element>
+        <element id="Coverage.payor:payerPerson">
+            <path value="Coverage.payor"/>
+            <sliceName value="payerPerson"/>
+            <short value="PayerPerson"/>
+            <definition value="Container of the PayerPerson concept. This container contains all data elements of the PayerPerson concept.In this a person is a natural person or a juridical person, such as an organization, municipality, etc."/>
+            <comment value="If the resource referenced is conformant to one of the target zib profiles, these profiles provide a mapping to the relevant zib Payer concepts. If it is not of conformant to one of these zib profiles, it SHALL have at least the following FHIR elements filled to be compliant with the subsequent zib Payer concepts:&#xD;&#xA;* `name.text` - PayerPerson::PayerName (NL-CM:1.1.5)&#xD;&#xA;* `address` - AddressInformation (NL-CM:1.1.17)&#xD;&#xA;* `telecom` - ContactInformation (NL-CM:1.1.12)"/>
+            <alias value="BetalerPersoon"/>
+            <max value="1"/>
+            <type>
+                <code value="Reference"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.2"/>
+                <comment value="PayerPerson"/>
+            </mapping>
+        </element>
+        <element id="Coverage.payor:payerPerson.extension">
+            <path value="Coverage.payor.extension"/>
+            <slicing>
+                <discriminator>
+                    <type value="value"/>
+                    <path value="url"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+        </element>
+        <element id="Coverage.payor:payerPerson.extension:bankInformation">
+            <path value="Coverage.payor.extension"/>
+            <sliceName value="bankInformation"/>
+            <type>
+                <code value="Extension"/>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
+            </type>
+        </element>
+        <element id="Coverage.payor:insuranceCompany">
+            <path value="Coverage.payor"/>
+            <sliceName value="insuranceCompany"/>
+            <short value="InsuranceCompany"/>
+            <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept."/>
+            <alias value="Verzekeraar"/>
+            <max value="1"/>
+            <type>
+                <code value="Reference"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.3"/>
+                <comment value="InsuranceCompany"/>
+            </mapping>
+        </element>
+    </differential>
 </StructureDefinition>

--- a/resources/zib/zib-Payer.xml
+++ b/resources/zib/zib-Payer.xml
@@ -33,6 +33,7 @@
             <path value="Coverage"/>
             <short value="Payer / Insurance"/>
             <definition value="* Root concept of the Payer information model. This root concept contains all data elements of the Payer information model.&#xD;&#xA;* Container of the Insurance concept. This container contains all data elements of the Insurance concept."/>
+            <comment value="The zib Payer is mapped to this Coverage profile and a profile on Organization (&amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization&amp;gt;). This Coverage profile acts as the focal resource of Payer, although Coverage is more associated with the Insurance container of the zib then with Payer as a whole. Nevertheless, the Coverage resource acts as an overarching resource that references the various resources that represent PayerPerson or InsuranceCompany and adds details like BankInformation. For the InsuranceCompany concept, the profile on Organization is used which is referenced using the `payor` element."/>
             <alias value="Betaler"/>
             <alias value="Verzekering"/>
             <mapping>

--- a/resources/zib/zib-Payer.xml
+++ b/resources/zib/zib-Payer.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="zib-Payer"/>
+    <url value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer"/>
+    <name value="ZibPayer"/>
+    <title value="zib Payer"/>
+    <status value="draft"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="email"/>
+            <value value="info@nictiz.nl"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <description value="Payers are organizations or individuals that pay for the healthcare supplied to the patient. These organizations or individuals can be: facilities or people who financially guarantee or who are responsible for the patient (such as parents or guardians of minors), organizations with direct financial responsibility, combinations of these or the patient themselves."/>
+    <purpose value="This Coverage resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Payer-v3.1.1(2020EN)](https://zibs.nl/wiki/Payer-v3.1.1(2020EN))."/>
+    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="zib-payer-v3.1.1-2020EN"/>
+        <uri value="https://zibs.nl/wiki/Payer-v3.1.1(2020EN)"/>
+        <name value="zib Payer-v3.1.1(2020EN)"/>
+    </mapping>
+    <kind value="resource"/>
+    <abstract value="true"/>
+    <type value="Coverage"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Coverage"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Coverage">
+            <path value="Coverage"/>
+            <short value="Payer / Insurance"/>
+            <definition value="* Root concept of the Payer information model. This root concept contains all data elements of the Payer information model.&#xD;&#xA;* Container of the Insurance concept. This container contains all data elements of the Insurance concept."/>
+            <alias value="Betaler"/>
+            <alias value="Verzekering"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.1"/>
+                <comment value="Payer"/>
+            </mapping>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.8"/>
+                <comment value="Insurance"/>
+            </mapping>
+        </element>
+        <element id="Coverage.identifier">
+            <path value="Coverage.identifier"/>
+            <short value="InsurantNumber"/>
+            <definition value="Number under which the insured person is registered at the insurance company This item maps the ‘Identification number of the card’ on EHIC field 8"/>
+            <alias value="VerzekerdeNummer"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.6"/>
+                <comment value="InsurantNumber"/>
+            </mapping>
+        </element>
+        <element id="Coverage.type">
+            <path value="Coverage.type"/>
+            <short value="InsuranceType"/>
+            <definition value="Type of insurance policy. Codes as returned in the Check for Right to Insurance"/>
+            <alias value="Verzekeringssoort"/>
+            <binding>
+                <strength value="required"/>
+                <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.1.1.1--20200901000000"/>
+            </binding>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.15"/>
+                <comment value="InsuranceType"/>
+            </mapping>
+        </element>
+        <element id="Coverage.period.start">
+            <path value="Coverage.period.start"/>
+            <short value="StartDateTime"/>
+            <definition value="Date from which the insurance policy coverage applies."/>
+            <alias value="BeginDatumTijd"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.13"/>
+                <comment value="StartDateTime"/>
+            </mapping>
+        </element>
+        <element id="Coverage.period.end">
+            <path value="Coverage.period.end"/>
+            <short value="EndDateTime"/>
+            <definition value="Date until which the insurance policy coverage applies. This item maps the ‘Expiry date’ on EHIC field 9."/>
+            <alias value="EindDatumTijd"/>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.14"/>
+                <comment value="EndDateTime"/>
+            </mapping>
+        </element>
+        <element id="Coverage.payor">
+            <path value="Coverage.payor"/>
+            <slicing>
+                <discriminator>
+                    <type value="profile"/>
+                    <path value="resolve()"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+            <max value="1"/>
+        </element>
+        <element id="Coverage.payor:payerPerson">
+            <path value="Coverage.payor"/>
+            <sliceName value="payerPerson"/>
+            <short value="PayerPerson"/>
+            <definition value="Container of the PayerPerson concept. This container contains all data elements of the PayerPerson concept.In this a person is a natural person or a juridical person, such as an organization, municipality, etc."/>
+            <comment value="If the resource referenced is conformant to one of the target zib profiles, these profiles provide a mapping to the relevant zib Payer concepts. If it is not of conformant to one of these zib profiles, it SHALL have at least the following FHIR elements filled to be compliant with the subsequent zib Payer concepts:&#xD;&#xA;* `name.text` - PayerPerson::PayerName (NL-CM:1.1.5)&#xD;&#xA;* `address` - AddressInformation (NL-CM:1.1.17)&#xD;&#xA;* `telecom` - ContactInformation (NL-CM:1.1.12)"/>
+            <alias value="BetalerPersoon"/>
+            <max value="1"/>
+            <type>
+                <code value="Reference"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
+                <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.2"/>
+                <comment value="PayerPerson"/>
+            </mapping>
+        </element>
+        <element id="Coverage.payor:payerPerson.extension">
+            <path value="Coverage.payor.extension"/>
+            <slicing>
+                <discriminator>
+                    <type value="value"/>
+                    <path value="url"/>
+                </discriminator>
+                <rules value="open"/>
+            </slicing>
+        </element>
+        <element id="Coverage.payor:payerPerson.extension:bankInformation">
+            <path value="Coverage.payor.extension"/>
+            <sliceName value="bankInformation"/>
+            <type>
+                <code value="Extension"/>
+                <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Payer.BankInformation"/>
+            </type>
+        </element>
+        <element id="Coverage.payor:insuranceCompany">
+            <path value="Coverage.payor"/>
+            <sliceName value="insuranceCompany"/>
+            <short value="InsuranceCompany"/>
+            <definition value="Container of the InsuranceCompany concept. This container contains all data elements of the InsuranceCompany concept."/>
+            <alias value="Verzekeraar"/>
+            <max value="1"/>
+            <type>
+                <code value="Reference"/>
+                <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Payer-Organization"/>
+            </type>
+            <mapping>
+                <identity value="zib-payer-v3.1.1-2020EN"/>
+                <map value="NL-CM:1.1.3"/>
+                <comment value="InsuranceCompany"/>
+            </mapping>
+        </element>
+    </differential>
+</StructureDefinition>


### PR DESCRIPTION
Still some errors in QA tooling:

profile validation: I have constructed a slice for resolve() profile = zib-Payer-Organization, while the Organization base profile 'lives' on another slice. (see profile, section on Coverage.payor). That is why the following error is shown:
```
== resources/zib/zib-Payer.xml (zib-Payer)
  -  error at StructureDefinition.differential.element[11].type[0] (178, 19):
     sd-zpg-03: 'References to other resource profiles should be added next to the HL7  base references.' Rule 'References to other resource profiles should be added next to the HL7  base references.' Failed
```
I guess this is a new use case that the QA does not account for, but I didn't want so silence the message right away. Maybe this construction doen't work at all.

To test the slicing construction mentioned above, I added a set of manual examples. However, because both validators do not properly recognize 'resolve()' (#116), it cannot really be tested.

zib-compliance: the following error still persists although I have added it to known-issues (it originally said `Extension instead of container`). But error type 'undefined' shows me this is not something expected.
```
==== snapshots/zib-Payer.json
     == NL-CM:1.1.4 (Coverage.payor:payerPerson.extension:bankInformation)
        datatype:    undefined (Extension instead of Extension)
```
@pieter-edelman-nictiz , maybe you can look into this?