### PR TITLE
zib MultidisciplinaryTeamMeeting

### DIFF
--- a/resources/zib/ext-Encounter-PatientParticipant.xml
+++ b/resources/zib/ext-Encounter-PatientParticipant.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ext-Encounter-PatientParticipant" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ext-Encounter-PatientParticipant" />
+  <name value="ExtEncounterPatientParticipant" />
+  <status value="draft" />
+  <description value="This extension adds zib-Patient as a target profile to `Encounter.participant.individual`. Our zib profiles based on Encounter pre-adopt the notion that the subject of the Encounter does not have to be present at the encounter (https://jira.hl7.org/browse/FHIR-20479). This creates the need to reference the subject in `Encounter.participant.individual` if the subject is present, where the current FHIR R5 build has already added this option to the renamed `participant.actor`." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="rim" />
+    <uri value="http://hl7.org/v3" />
+    <name value="RIM Mapping" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="Encounter.participant.individual" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-Encounter-PatientParticipant" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Patient" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib/ext-MultidisciplinaryTeamMeeting.IntentTreatment.xml
+++ b/resources/zib/ext-MultidisciplinaryTeamMeeting.IntentTreatment.xml
@@ -1,57 +1,59 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-    <id value="ext-MultidisciplinaryTeamMeeting.IntentTreatment"/>
-    <url value="http://nictiz.nl/fhir/StructureDefinition/ext-MultidisciplinaryTeamMeeting.IntentTreatment"/>
-    <name value="ExtMultidisciplinaryTeamMeetingIntentTreatment"/>
-    <title value="ext MultidisciplinaryTeamMeeting.IntentTreatment"/>
-    <status value="draft"/>
-    <publisher value="Nictiz"/>
-    <contact>
-        <name value="Nictiz"/>
-        <telecom>
-            <system value="email"/>
-            <value value="info@nictiz.nl"/>
-            <use value="work"/>
-        </telecom>
-    </contact>
-    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
-    <fhirVersion value="4.0.1"/>
-    <mapping>
-        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN"/>
-        <uri value="https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN)"/>
-        <name value="zib MultidisciplinaryTeamMeeting-v1.0(2020EN)"/>
-    </mapping>
-    <kind value="complex-type"/>
-    <abstract value="false"/>
-    <context>
-        <type value="element"/>
-        <expression value="CarePlan"/>
-    </context>
-    <type value="Extension"/>
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
-    <derivation value="constraint"/>
-    <differential>
-        <element id="Extension.url">
-            <path value="Extension.url"/>
-            <fixedUri value="https://example.org/fhir/StructureDefinition/MyExtension"/>
-        </element>
-        <element id="Extension.value[x]">
-            <path value="Extension.value[x]"/>
-            <short value="IntentTreatment"/>
-            <definition value="Intend of treatement. For instance conform protocol, curative or pain management, trial etc."/>
-            <alias value="IntentieBehandeling"/>
-            <type>
-                <code value="CodeableConcept"/>
-            </type>
-            <binding>
-                <strength value="extensible"/>
-                <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000"/>
-            </binding>
-            <mapping>
-                <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN"/>
-                <map value="NL-CM:15.2.11"/>
-                <comment value="IntentTreatment"/>
-            </mapping>
-        </element>
-    </differential>
+  <id value="ext-MultidisciplinaryTeamMeeting.IntentTreatment" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ext-MultidisciplinaryTeamMeeting.IntentTreatment" />
+  <name value="ExtMultidisciplinaryTeamMeetingIntentTreatment" />
+  <title value="ext MultidisciplinaryTeamMeeting.IntentTreatment" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="The concept IntentTreatment [zib MultidisciplinaryTeamMeeting v1.0(2020EN)](https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN)) cannot be properly mapped in the CarePlan resource, hence a custom extension is used." />
+  <purpose value="This extension represents the IntentTreatment concept of [zib MultidisciplinaryTeamMeeting v1.0(2020EN)](https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN))." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+    <uri value="https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN)" />
+    <name value="zib MultidisciplinaryTeamMeeting-v1.0(2020EN)" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="CarePlan" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-MultidisciplinaryTeamMeeting.IntentTreatment" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <short value="IntentTreatment" />
+      <definition value="Intend of treatement. For instance conform protocol, curative or pain management, trial etc." />
+      <alias value="IntentieBehandeling" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000" />
+      </binding>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.11" />
+        <comment value="IntentTreatment" />
+      </mapping>
+    </element>
+  </differential>
 </StructureDefinition>

--- a/resources/zib/ext-MultidisciplinaryTeamMeeting.IntentTreatment.xml
+++ b/resources/zib/ext-MultidisciplinaryTeamMeeting.IntentTreatment.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="ext-MultidisciplinaryTeamMeeting.IntentTreatment"/>
+    <url value="http://nictiz.nl/fhir/StructureDefinition/ext-MultidisciplinaryTeamMeeting.IntentTreatment"/>
+    <name value="ExtMultidisciplinaryTeamMeetingIntentTreatment"/>
+    <title value="ext MultidisciplinaryTeamMeeting.IntentTreatment"/>
+    <status value="draft"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="email"/>
+            <value value="info@nictiz.nl"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN"/>
+        <uri value="https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN)"/>
+        <name value="zib MultidisciplinaryTeamMeeting-v1.0(2020EN)"/>
+    </mapping>
+    <kind value="complex-type"/>
+    <abstract value="false"/>
+    <context>
+        <type value="element"/>
+        <expression value="CarePlan"/>
+    </context>
+    <type value="Extension"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Extension.url">
+            <path value="Extension.url"/>
+            <fixedUri value="https://example.org/fhir/StructureDefinition/MyExtension"/>
+        </element>
+        <element id="Extension.value[x]">
+            <path value="Extension.value[x]"/>
+            <short value="IntentTreatment"/>
+            <definition value="Intend of treatement. For instance conform protocol, curative or pain management, trial etc."/>
+            <alias value="IntentieBehandeling"/>
+            <type>
+                <code value="CodeableConcept"/>
+            </type>
+            <binding>
+                <strength value="extensible"/>
+                <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000"/>
+            </binding>
+            <mapping>
+                <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN"/>
+                <map value="NL-CM:15.2.11"/>
+                <comment value="IntentTreatment"/>
+            </mapping>
+        </element>
+    </differential>
+</StructureDefinition>

--- a/resources/zib/terminology/IntentieBehandelingCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000.xml
+++ b/resources/zib/terminology/IntentieBehandelingCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000.xml
@@ -1,0 +1,152 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000"/>
+    <meta>
+        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+    </meta>
+    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+        <valuePeriod>
+            <start value="2020-09-01T00:00:00+02:00"/>
+        </valuePeriod>
+    </extension>
+    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1--20200901000000"/>
+    <identifier>
+        <use value="official"/>
+        <system value="http://art-decor.org/ns/oids/vs"/>
+        <value value="2.16.840.1.113883.2.4.3.11.60.40.2.15.2.1"/>
+    </identifier>
+    <version value="2020-09-01T00:00:00"/>
+    <name value="IntentieBehandelingCodelijst"/>
+    <title value="IntentieBehandelingCodelijst"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Registratie aan de bron"/>
+    <contact>
+        <name value="Registratie aan de bron"/>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.registratieaandebron.nl"/>
+        </telecom>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.zibs.nl"/>
+        </telecom>
+    </contact>
+    <description value="IntentieBehandelingCodelijst"/>
+    <immutable value="false"/>
+    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+    <compose>
+        <include>
+            <system value="http://snomed.info/sct"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Behandeling conform richtlijn"/>
+                </extension>
+                <code value="370858005"/>
+                <display value="Following clinical pathway protocol"/>
+                <designation>
+                    <language value="en-US"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Following clinical pathway protocol"/>
+                </designation>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Volgen van klinisch zorgpad"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Curatieve behandeling"/>
+                </extension>
+                <code value="373808002"/>
+                <display value="Curative procedure intent"/>
+                <designation>
+                    <language value="en-US"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Curative - procedure intent"/>
+                </designation>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Curatieve intentie"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Palliatieve zorg"/>
+                </extension>
+                <code value="103735009"/>
+                <display value="Palliative care"/>
+                <designation>
+                    <language value="en-US"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Palliative care"/>
+                </designation>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Palliatieve zorg"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Toetsing van inclusiecriteria voor clinical trial"/>
+                </extension>
+                <code value="450332002"/>
+                <display value="Assessment of eligibility for clinical trial"/>
+                <designation>
+                    <language value="en-US"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Assessment of eligibility for clinical trial"/>
+                </designation>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="Beoordelen van geschiktheid voor deelname aan klinisch wetenschappelijk onderzoek"/>
+                </designation>
+            </concept>
+        </include>
+        <include>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Anders, specificieer"/>
+                </extension>
+                <code value="OTH"/>
+                <display value="Other"/>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/zib/terminology/RolDeelnemerCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.15.2.2--20200901000000.xml
+++ b/resources/zib/terminology/RolDeelnemerCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.15.2.2--20200901000000.xml
@@ -1,0 +1,99 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.15.2.2--20200901000000"/>
+    <meta>
+        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+    </meta>
+    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+        <valuePeriod>
+            <start value="2020-09-01T00:00:00+02:00"/>
+        </valuePeriod>
+    </extension>
+    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.2.2--20200901000000"/>
+    <identifier>
+        <use value="official"/>
+        <system value="http://art-decor.org/ns/oids/vs"/>
+        <value value="2.16.840.1.113883.2.4.3.11.60.40.2.15.2.2"/>
+    </identifier>
+    <version value="2020-09-01T00:00:00"/>
+    <name value="RolDeelnemerCodelijst"/>
+    <title value="RolDeelnemerCodelijst"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="Registratie aan de bron"/>
+    <contact>
+        <name value="Registratie aan de bron"/>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.registratieaandebron.nl"/>
+        </telecom>
+        <telecom>
+            <system value="url"/>
+            <value value="https://www.zibs.nl"/>
+        </telecom>
+    </contact>
+    <description value="RolDeelnemerCodelijst"/>
+    <immutable value="false"/>
+    <compose>
+        <include>
+            <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Anders, namelijk"/>
+                </extension>
+                <code value="OTH"/>
+                <display value="other"/>
+            </concept>
+        </include>
+        <include>
+            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.26.1"/>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Voorzitter van de patiëntbespreking"/>
+                </extension>
+                <code value="VOORZ"/>
+                <display value="voorzitter"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="voorzitter"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Aanmelder van de patiënt bij de bespreking"/>
+                </extension>
+                <code value="AANM"/>
+                <display value="aanmelder"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="aanmelder"/>
+                </designation>
+            </concept>
+            <concept>
+                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+                    <valueString value="Inhoudelijk expert bij de bespreking"/>
+                </extension>
+                <code value="EXPR"/>
+                <display value="expert"/>
+                <designation>
+                    <language value="nl-NL"/>
+                    <use>
+                        <system value="http://snomed.info/sct"/>
+                        <code value="900000000000013009"/>
+                        <display value="Synonym"/>
+                    </use>
+                    <value value="expert"/>
+                </designation>
+            </concept>
+        </include>
+    </compose>
+</ValueSet>

--- a/resources/zib/zib-MultidisciplinaryTeamMeeting-CarePlan.xml
+++ b/resources/zib/zib-MultidisciplinaryTeamMeeting-CarePlan.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="zib-MultidisciplinaryTeamMeeting-CarePlan" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/zib-MultidisciplinaryTeamMeeting-CarePlan" />
+  <name value="ZibMultidisciplinaryTeamMeetingCarePlan" />
+  <title value="zib MultidisciplinaryTeamMeeting CarePlan" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="A multidisciplinary team meeting is a meeting of health care providers in which the results of examinations and treatment are discussed with the aim of formulating joint advice for the treatment of the patient. A patient can also be present. When healthcare professionals from various disciplines participate, and this is structurally organized (local, regional, sub regional or through a partnership), this is often referred to as a multi-disciplinary consultation ." />
+  <purpose value="This CarePlan resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) MultidisciplinaryTeamMeeting-v1.0(2020EN)](https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN))." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+    <uri value="https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN)" />
+    <name value="zib MultidisciplinaryTeamMeeting-v1.0(2020EN)" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="true" />
+  <type value="CarePlan" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/CarePlan" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="CarePlan">
+      <path value="CarePlan" />
+      <comment value="Zib MultidisciplinaryTeamMeeting is mapped to this CarePlan profile and a profile on Encounter (&amp;amp;amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-MultidisciplinaryTeamMeeting&amp;amp;amp;gt;), which acts as the focal resource of MultidisciplinaryTeamMeeting. &#xD;&#xA;&#xD;&#xA;This profile references the Encounter resource through `.encounter`." />
+    </element>
+    <element id="CarePlan.extension">
+      <path value="CarePlan.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="CarePlan.extension:intentTreatment">
+      <path value="CarePlan.extension" />
+      <sliceName value="intentTreatment" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="https://example.org/fhir/StructureDefinition/MyExtension" />
+      </type>
+    </element>
+    <element id="CarePlan.encounter">
+      <path value="CarePlan.encounter" />
+      <short value="Plan" />
+      <definition value="Container of the Plan concept.This container contains all data elements of the Plan concept." />
+      <alias value="Beleid" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Encounter" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-MultidisciplinaryTeamMeeting" />
+      </type>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.10" />
+        <comment value="Plan" />
+      </mapping>
+    </element>
+    <element id="CarePlan.activity.reference">
+      <path value="CarePlan.activity.reference" />
+      <short value="ProposedTreatment" />
+      <definition value="Proposed treatment." />
+      <alias value="VoorgesteldeBehandeling" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Appointment" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/CommunicationRequest" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/DeviceRequest" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/MedicationRequest" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/NutritionOrder" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Task" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/ServiceRequest" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/VisionPrescription" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RequestGroup" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Procedure-ServiceRequest" />
+      </type>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.12" />
+        <comment value="ProposedTreatment" />
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib/zib-MultidisciplinaryTeamMeeting-CarePlan.xml
+++ b/resources/zib/zib-MultidisciplinaryTeamMeeting-CarePlan.xml
@@ -49,7 +49,7 @@
       <max value="1" />
       <type>
         <code value="Extension" />
-        <profile value="https://example.org/fhir/StructureDefinition/MyExtension" />
+          <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-MultidisciplinaryTeamMeeting.IntentTreatment" />
       </type>
     </element>
     <element id="CarePlan.encounter">

--- a/resources/zib/zib-MultidisciplinaryTeamMeeting.xml
+++ b/resources/zib/zib-MultidisciplinaryTeamMeeting.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="zib-MultidisciplinaryTeamMeeting" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/zib-MultidisciplinaryTeamMeeting" />
+  <name value="ZibMultidisciplinaryTeamMeeting" />
+  <title value="zib MultidisciplinaryTeamMeeting" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="A multidisciplinary team meeting is a meeting of health care providers in which the results of examinations and treatment are discussed with the aim of formulating joint advice for the treatment of the patient. A patient can also be present. When healthcare professionals from various disciplines participate, and this is structurally organized (local, regional, sub regional or through a partnership), this is often referred to as a multi-disciplinary consultation ." />
+  <purpose value="This Encounter resource represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) MultidisciplinaryTeamMeeting-v1.0(2020EN)](https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN))." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+    <uri value="https://zibs.nl/wiki/MultidisciplinaryTeamMeeting-v1.0(2020EN)" />
+    <name value="zib MultidisciplinaryTeamMeeting-v1.0(2020EN)" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="true" />
+  <type value="Encounter" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Encounter" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Encounter">
+      <path value="Encounter" />
+      <short value="MultidisciplinaryTeamMeeting" />
+      <alias value="Patientbespreking" />
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.1" />
+        <comment value="MultidisciplinaryTeamMeeting" />
+      </mapping>
+    </element>
+    <element id="Encounter.type.text">
+      <path value="Encounter.type.text" />
+      <short value="PatientConsultationLabel" />
+      <definition value="The name used to identify the particular patient consultation, e.g. MDC head and neck cancer." />
+      <alias value="PatientbesprekingLabel" />
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.5" />
+        <comment value="PatientConsultationLabel" />
+      </mapping>
+    </element>
+    <element id="Encounter.subject">
+      <path value="Encounter.subject" />
+      <short value="The patient or group related to this encounter" />
+      <definition value="The patient or group related to this encounter. (Note: this definition is a pre-adopt of https://jira.hl7.org/browse/FHIR-20479. Referencing the Patient as `.subject` does not indicate its precense at the Encounter. Use `.participant.individual.extension:patient` for this.)" />
+    </element>
+    <element id="Encounter.participant">
+      <path value="Encounter.participant" />
+      <short value="Participant" />
+      <definition value="Container of the Participant concept.This container contains all data elements of the Participant concept." />
+      <alias value="Deelnemer" />
+      <min value="2" />
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.13" />
+        <comment value="Participant" />
+      </mapping>
+    </element>
+    <element id="Encounter.participant.type">
+      <path value="Encounter.participant.type" />
+      <short value="RolDeelnemer" />
+      <definition value="Role of the person in the patient meeting, for example chairman, expert, notifier, secretary." />
+      <alias value="RolDeelnemer" />
+      <binding>
+        <strength value="extensible" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.15.2.2--20200901000000" />
+      </binding>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.14" />
+        <comment value="RolDeelnemer" />
+      </mapping>
+    </element>
+    <element id="Encounter.participant.individual">
+      <path value="Encounter.participant.individual" />
+      <slicing>
+        <discriminator>
+          <type value="exists" />
+          <path value="extension.url" />
+        </discriminator>
+        <discriminator>
+          <type value="profile" />
+          <path value="resolve()" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Encounter.participant.individual:healthProfessional">
+      <path value="Encounter.participant.individual" />
+      <sliceName value="healthProfessional" />
+      <short value="HealthProfessional" />
+      <definition value="Health professional as participant of the patient consultation." />
+      <alias value="Zorgverlener" />
+      <type>
+        <code value="Reference" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/pattern-ZibHealthProfessionalReference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-HealthProfessional-PractitionerRole" />
+      </type>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.3" />
+        <comment value="HealthProfessional" />
+      </mapping>
+    </element>
+    <element id="Encounter.participant.individual:contactPerson">
+      <path value="Encounter.participant.individual" />
+      <sliceName value="contactPerson" />
+      <short value="Contactperson" />
+      <definition value="Contactperson as participant of the patient consultation." />
+      <alias value="Contactpersoon" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson" />
+      </type>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.15" />
+        <comment value="Contactperson" />
+      </mapping>
+    </element>
+    <element id="Encounter.participant.individual:patient">
+      <path value="Encounter.participant.individual" />
+      <sliceName value="patient" />
+    </element>
+    <element id="Encounter.participant.individual:patient.extension">
+      <path value="Encounter.participant.individual.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Encounter.participant.individual:patient.extension:patient">
+      <path value="Encounter.participant.individual.extension" />
+      <sliceName value="patient" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Encounter-PatientParticipant" />
+      </type>
+    </element>
+    <element id="Encounter.participant.individual:patient.extension:patient.value[x]">
+      <path value="Encounter.participant.individual.extension.value[x]" />
+      <short value="Patient" />
+      <definition value="The patient as participant of the patient consultation." />
+      <alias value="Patient" />
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.16" />
+        <comment value="Patient" />
+      </mapping>
+    </element>
+    <element id="Encounter.period">
+      <path value="Encounter.period" />
+      <comment value="'PatientConsultationDateTime' is mapped to both `period.start` and `period.end`. When all is known is a single value, both `.start` and `.end` should be populated with this value, otherwise the `period`, and thus the MultidisciplinaryTeamMetting, is considered 'ongoing'. In FHIR R4, the Period datatype has an invariant that inconsistently says in text that Period.start shall be lower than Period.end, but actually supports lower than or equal in its expression, which reflects the original intent. This has been fixed for FHIR R5; the text now reflects the expression. &#xD;&#xA;&#xD;&#xA;When a system is able to populate both `period.start` and `period.end`, the value of `.start` is leading when converting FHIR data to a zib instance." />
+    </element>
+    <element id="Encounter.period.start">
+      <path value="Encounter.period.start" />
+      <short value="PatientConsultationDateTime" />
+      <definition value="The date (and time) the patient consultation is scheduled or took place." />
+      <alias value="PatientbesprekingDatumTijd" />
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.6" />
+        <comment value="PatientConsultationDateTime" />
+      </mapping>
+    </element>
+    <element id="Encounter.period.end">
+      <path value="Encounter.period.end" />
+      <short value="PatientConsultationDateTime" />
+      <definition value="The date (and time) the patient consultation is scheduled or took place." />
+      <alias value="PatientbesprekingDatumTijd" />
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.6" />
+        <comment value="PatientConsultationDateTime" />
+      </mapping>
+    </element>
+    <element id="Encounter.reasonReference">
+      <path value="Encounter.reasonReference" />
+      <slicing>
+        <discriminator>
+          <type value="profile" />
+          <path value="resolve()" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Encounter.reasonReference:disease">
+      <path value="Encounter.reasonReference" />
+      <sliceName value="disease" />
+      <short value="Disease" />
+      <definition value="The disease or patient problem that is the reason for the patient consultation." />
+      <alias value="Aandoening" />
+      <max value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Condition" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
+      </type>
+      <mapping>
+        <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
+        <map value="NL-CM:15.2.7" />
+        <comment value="Disease" />
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib/zib-MultidisciplinaryTeamMeeting.xml
+++ b/resources/zib/zib-MultidisciplinaryTeamMeeting.xml
@@ -32,6 +32,7 @@
     <element id="Encounter">
       <path value="Encounter" />
       <short value="MultidisciplinaryTeamMeeting" />
+      <comment value="Zib MultidisciplinaryTeamMeeting is mapped to this Encounter profile and a profile on CarePlan (&amp;amp;amp;lt;http://nictiz.nl/fhir/StructureDefinition/zib-MultidisciplinaryTeamMeeting-CarePlanMedia&amp;amp;amp;gt;). This Encounter profile acts as the focal resource of MultidisciplinaryTeamMeeting. This profile is referenced by the CarePlan resource, which holds the 'Plan' concept (NL-CM:15.2.10), through `CarePlan.encounter`." />
       <alias value="Patientbespreking" />
       <mapping>
         <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
@@ -60,7 +61,6 @@
       <short value="Participant" />
       <definition value="Container of the Participant concept.This container contains all data elements of the Participant concept." />
       <alias value="Deelnemer" />
-      <min value="2" />
       <mapping>
         <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
         <map value="NL-CM:15.2.13" />
@@ -84,58 +84,31 @@
     </element>
     <element id="Encounter.participant.individual">
       <path value="Encounter.participant.individual" />
-      <slicing>
-        <discriminator>
-          <type value="exists" />
-          <path value="extension.url" />
-        </discriminator>
-        <discriminator>
-          <type value="profile" />
-          <path value="resolve()" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-    </element>
-    <element id="Encounter.participant.individual:healthProfessional">
-      <path value="Encounter.participant.individual" />
-      <sliceName value="healthProfessional" />
-      <short value="HealthProfessional" />
-      <definition value="Health professional as participant of the patient consultation." />
+      <short value="HealthProfessional / Contactperson" />
+      <definition value="* Health professional as participant of the patient consultation.&#xD;&#xA;* Contactperson as participant of the patient consultation." />
       <alias value="Zorgverlener" />
+      <alias value="Contactpersoon" />
       <type>
         <code value="Reference" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/pattern-ZibHealthProfessionalReference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-HealthProfessional-PractitionerRole" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson" />
       </type>
       <mapping>
         <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
         <map value="NL-CM:15.2.3" />
         <comment value="HealthProfessional" />
       </mapping>
-    </element>
-    <element id="Encounter.participant.individual:contactPerson">
-      <path value="Encounter.participant.individual" />
-      <sliceName value="contactPerson" />
-      <short value="Contactperson" />
-      <definition value="Contactperson as participant of the patient consultation." />
-      <alias value="Contactpersoon" />
-      <type>
-        <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-ContactPerson" />
-      </type>
       <mapping>
         <identity value="zib-multidisciplinaryteammeeting-v1.0-2020EN" />
         <map value="NL-CM:15.2.15" />
         <comment value="Contactperson" />
       </mapping>
     </element>
-    <element id="Encounter.participant.individual:patient">
-      <path value="Encounter.participant.individual" />
-      <sliceName value="patient" />
-    </element>
-    <element id="Encounter.participant.individual:patient.extension">
+    <element id="Encounter.participant.individual.extension">
       <path value="Encounter.participant.individual.extension" />
       <slicing>
         <discriminator>
@@ -145,15 +118,16 @@
         <rules value="open" />
       </slicing>
     </element>
-    <element id="Encounter.participant.individual:patient.extension:patient">
+    <element id="Encounter.participant.individual.extension:patient">
       <path value="Encounter.participant.individual.extension" />
       <sliceName value="patient" />
+      <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-Encounter-PatientParticipant" />
       </type>
     </element>
-    <element id="Encounter.participant.individual:patient.extension:patient.value[x]">
+    <element id="Encounter.participant.individual.extension:patient.value[x]">
       <path value="Encounter.participant.individual.extension.value[x]" />
       <short value="Patient" />
       <definition value="The patient as participant of the patient consultation." />


### PR DESCRIPTION
To do: but not by me I guess

release-notes? New zib so I don't know if that is necessary
known-issues:
==== snapshots/zib-MultidisciplinaryTeamMeeting-CarePlan.json
     == NL-CM:15.2.12 (CarePlan.activity.reference)
        cardinality: ERROR (0..1 instead of 0..*)
==== snapshots/zib-MultidisciplinaryTeamMeeting.json
     == NL-CM:15.2.13 (Encounter.participant)
        datatype:    ERROR (BackboneElement instead of container)
        cardinality: ERROR (0..* instead of 1..*)

First one (CarePlan.activity.reference) can be silenced, because .activity has 0..* resulting in that effective cardinality
BackboneElement instead of container is #76 
Cardinality 0..* instead of 1..* is the issue in zib validation tooling as I mentioned yesterday. zib cardinality is 2..*, the tooling makes is a conceptual 1..*, but I feel it should be 0..*. No ticket made yet.

For the rest a normal review can be done