### PR TITLE
Nationale Terminologieserver

### DIFF
--- a/util/qa-All.bat
+++ b/util/qa-All.bat
@@ -1,3 +1,3 @@
 @echo off
-docker-compose --env-file qaAutomation\nts-credentials.env -f qaAutomation/docker-compose.yml run --rm -p 8081:8081 validate
+docker-compose --env-file qaAutomation/nts-credentials.env -f qaAutomation/docker-compose.yml run --rm -p 8081:8081 validate
 pause

--- a/util/qa-All.bat
+++ b/util/qa-All.bat
@@ -1,3 +1,3 @@
 @echo off
-docker-compose -f qaAutomation/docker-compose.yml run --rm validate
+docker-compose --env-file qaAutomation\nts-credentials.env -f qaAutomation/docker-compose.yml run --rm -p 8081:8081 validate
 pause

--- a/util/qa-Changed.bat
+++ b/util/qa-Changed.bat
@@ -1,3 +1,3 @@
 @echo off
-docker-compose --env-file qaAutomation\nts-credentials.env -f qaAutomation/docker-compose.yml run --rm -p 8081:8081 validate
+docker-compose --env-file qaAutomation/nts-credentials.env -f qaAutomation/docker-compose.yml run --rm -p 8081:8081 validate
 pause

--- a/util/qa-Changed.bat
+++ b/util/qa-Changed.bat
@@ -1,3 +1,3 @@
 @echo off
-docker-compose -f qaAutomation/docker-compose.yml run --rm validate
+docker-compose --env-file qaAutomation\nts-credentials.env -f qaAutomation/docker-compose.yml run --rm -p 8081:8081 validate
 pause

--- a/util/qaAutomation/.gitignore
+++ b/util/qaAutomation/.gitignore
@@ -1,0 +1,1 @@
+nts-credentials.env

--- a/util/qaAutomation/CombinedTX/CombinedTX.py
+++ b/util/qaAutomation/CombinedTX/CombinedTX.py
@@ -1,0 +1,271 @@
+import os
+import os.path
+import re
+import requests
+from mitmproxy import ctx, http
+import xml.etree.ElementTree as ET
+
+""" 
+An HTTP proxy that combines the capabilities of the default FHIR terminology server (fhir.tx.org) and the Nationale
+Terminologieserver (terminologieserver.nl).
+
+The proxy is an addon for MITMProxy. It can be invoked using the `-s CombinedTX.py` flag in one of the commands.
+
+The Nationale Terminologieserver requires an account with proper permissions. The username and password should be set
+in the environment variables NTS_USER and NTS_PASS.
+"""
+class CombinedTX:
+    PROXY_HOSTNAME    = "combined.tx"
+    PROXY_HOSTNAME_V3 = "v3." + PROXY_HOSTNAME
+    PROXY_HOSTNAME_V4 = "v4." + PROXY_HOSTNAME
+
+    NTS_HOSTNAME = "terminologieserver.nl"
+    NTS_PATH     = "/fhir"
+    NTS_SCHEME   = "https://"
+    NTS_HOST     = NTS_SCHEME + NTS_HOSTNAME + NTS_PATH
+
+    DTX_HOSTNAME = "tx.fhir.org"
+    DTX_PATH_V3  = "/r3"
+    DTX_PATH_V4  = "/r4"
+    DTX_SCHEME   = "http://"
+    DTX_HOST     = DTX_SCHEME + DTX_HOSTNAME
+
+    PATH_METADATA_SUMMARY     = "/metadata?_summary=true"
+    PATH_METADATA_TERMINOLOGY = "/metadata?mode=terminology"
+    PATH_VALIDATE             = "/$validate-code"
+
+    FHIR_NAMESPACE = {"f": "http://hl7.org/fhir"}
+
+    def __init__(self):
+        # We keep a list of CodeSystems which both servers support so we can route the call to the proper server
+        self.codesystems_dtx = set()
+        self.codesystems_nts = set()
+
+        try:
+            os.environ["NTS_USER"]
+            os.environ["NTS_PASS"]
+            self._support_nts = True
+        except:
+            print("Environment variables NTS_USER and NTS_PASS are not set. Disabling support for the Nationale Terminologieserver")
+            ctx.log.info("Environment variables NTS_USER and NTS_PASS are not set. Disabling support for the Nationale Terminologieserver")
+            self._support_nts = False
+
+        # Cache the token for calls to the NTS
+        self._nts_token = None
+
+        # The path where we can find our fixtures
+        self._fixture_path = os.path.join(os.path.dirname(__file__), "fixtures")
+
+    def request(self, flow):
+        if flow.request.pretty_host in [self.PROXY_HOSTNAME_V3, self.PROXY_HOSTNAME_V4]:
+            fhir_version = 4 if flow.request.pretty_host == self.PROXY_HOSTNAME_V4 else 3
+
+            if flow.request.path.endswith(self.PATH_VALIDATE):
+                # If the system being validated is not present on the default TX but only on the NTS, route the request 
+                # to the NTS
+                tree = ET.fromstring(flow.request.content.decode("UTF-8"))
+                system = tree.findall("./f:parameter/f:name[@value='coding']../f:valueCoding/f:system", self.FHIR_NAMESPACE)[0].attrib["value"]
+                
+                if len(self.codesystems_dtx) == 0:
+                    refreshed = self._refreshCodeSystems(fhir_version)
+                    if refreshed != True:
+                        flow.response = refreshed
+                        return
+
+                if system not in self.codesystems_dtx and system in self.codesystems_nts:
+                    ctx.log.info(f"Rerouting request for system '{system}' to NTS")
+                    headers = {
+                        "Content-Type": f"application/fhir+xml; fhirVersion={fhir_version}.0",
+                        "Accept": f"application/fhir+xml; fhirVersion={fhir_version}.0"
+                    }
+                    response = self._makeNTSRequest(flow.request.path, fhir_version, body = flow.request.content)
+                    if response.status_code == requests.codes.ok:
+                        flow.response = http.HTTPResponse.make(200, response.content, {"Content-Type": "application/fhir+xml"})
+                        flow.response.headers["TX-Origin"] = self.NTS_HOSTNAME
+                        return
+                    else:
+                        flow.response = self._createFailureResponse(400, "Couldn't validate code on " + self.NTS_HOSTNAME)
+                        return
+                    return
+            elif flow.request.path == self.PATH_METADATA_SUMMARY:
+                flow.response = self._getMetadataSummary(fhir_version)
+                return
+            elif flow.request.path == self.PATH_METADATA_TERMINOLOGY:
+                flow.response = self._getMetadataTerminology(flow, fhir_version)
+                return
+
+            # By default, route the request to the default TX server
+            flow.request.host = self.DTX_HOSTNAME
+            flow.request.path = (self.DTX_PATH_V3 if fhir_version == 3 else self.DTX_PATH_V4) + flow.request.path
+    
+    def response(self, flow):
+        if flow.request.pretty_host == self.DTX_HOSTNAME:
+            tx_origin = self.DTX_HOST
+
+            # If the default server fails to validate a code but the CodeSystem is supported by the NTS, we can try 
+            # again to see if it will validate there.
+            if flow.response.status_code == 200 and flow.request.path.endswith(self.PATH_VALIDATE):
+
+                tree = ET.fromstring(flow.response.content.decode("UTF-8"))
+
+                # The result of the operation                
+                result = tree.findall("./f:parameter/f:name[@value='result']../f:valueBoolean", self.FHIR_NAMESPACE)[0].attrib["value"]
+                
+                # If the display is deemed incorrect, the result is still true but a message will be appended, which 
+                # we'll have to analyze 
+                invalid_display = False
+                for message in tree.findall("./f:parameter/f:name[@value='message']../f:valueString", self.FHIR_NAMESPACE):
+                    if re.match('The display ".*" is not a valid display for the code', message.attrib["value"]):
+                        invalid_display = True
+                        break
+
+                if result == "false" or invalid_display:
+                    # Send a request to the NTS
+                    fhir_version = 4 if flow.request.path.startswith(self.DTX_PATH_V4) else 3
+                    if fhir_version == 3:
+                        path = flow.request.path.replace(self.DTX_PATH_V3, "")
+                    else:
+                        path = flow.request.path.replace(self.DTX_PATH_V4, "")
+                    response = self._makeNTSRequest(path, fhir_version, body = flow.request.content.decode("UTF-8"))
+                    if response != False and response.status_code == requests.codes.ok:
+                        flow.response.content = response.content
+                        tx_origin = self.NTS_HOST
+            
+            # Add a header to identify the actual origin of the tx server
+            flow.response.headers["TX-Origin"] = tx_origin
+
+    def _getMetadataSummary(self, fhir_version):
+        """ Return a response to /metadata?_summary=true """
+        if fhir_version == 3:
+            fixture = open(os.path.join(self._fixture_path, "CapabilityStatement-v3.xml")).read()
+        elif fhir_version == 4:
+            fixture = open(os.path.join(self._fixture_path, "CapabilityStatement-v4.xml")).read()
+        return http.HTTPResponse.make(200, fixture, {"Content-Type": "application/fhir+xml"})
+
+    def _refreshCodeSystems(self, fhir_version):
+        ctx.log.info("Refreshing list of code systems")
+
+        # Request all known CodeSystems from the NTS. The CapabilityStatement of the NTS is broken, so we have to query
+        # the CodeSystems directly
+        response = self._makeNTSRequest("/CodeSystem", fhir_version, accept_json = True)
+        if response == False:
+            self._codesystems_nts = set()
+        elif response.status_code == requests.codes.ok:
+            json = response.json()
+            self.codesystems_nts = set([e["resource"]["url"] for e in json["entry"] if e["resource"]["resourceType"] == "CodeSystem"])
+        else:
+            return self._createFailureResponse(400, "Couldn't get CodeSystems from NTS")
+
+        # Request all known CodeSystems on the default tx
+        headers = {"Accept": "application/fhir+json; fhirVersion=4.0"}
+        response = requests.get(self.DTX_HOST + self.DTX_PATH_V4 + self.PATH_METADATA_TERMINOLOGY, headers = headers)
+        if response.status_code == requests.codes.ok:
+            json = response.json()
+            self.codesystems_dtx = set([c["uri"] for c in json["codeSystem"]])
+        else:
+            return self._createFailureResponse(400, "Couldn't get CodeSystems from the default tx server")
+
+        return True
+
+    def _getMetadataTerminology(self, flow, fhir_version):
+        """ Create a response to /metadata?terminology=true, with a combined TerminologyCapabilities/Parameters
+            instance for the default FHIR tx and the NTS. """
+
+        if len(self.codesystems_dtx) == 0 or len(self.codesystems_nts) == 0:
+            refreshed = self._refreshCodeSystems(fhir_version)
+            if refreshed != True:
+                return refreshed
+
+        if fhir_version == 3:
+            ctx.log.info("Creating combined Parameters to provide terminology capabilities")
+            fixture = open(os.path.join(self._fixture_path, "Parameters-terminology_capabilities.xml")).read()
+            fixture = fixture.replace("<parameter/>", '<parameter><name value="system"/><valueUri value="' + '"/></parameter><parameter><name value="system"/><valueUri value="'.join(self.codesystems_nts.union(self.codesystems_dtx)) + '"/></parameter>')
+            return http.HTTPResponse.make(200, fixture.encode("UTF-8"), {"Content-Type": "application/fhir+xml"})
+        elif fhir_version == 4:
+            # Create a TerminologyCapabilities instance with the CodeSystems
+            ctx.log.info("Creating combined TerminologyCapabilities")
+            fixture = open(os.path.join(self._fixture_path, "TerminologyCapabilities.xml")).read()
+            fixture = fixture.replace("<codeSystem/>", '<codeSystem><uri value="' + '"/></codeSystem><codeSystem><uri value="'.join(self.codesystems_nts.union(self.codesystems_dtx)) + '"/></codeSystem>')
+            return http.HTTPResponse.make(200, fixture.encode("UTF-8"), {"Content-Type": "application/fhir+xml"})
+
+    def _createFailureResponse(self, response_code, diagnostics, code = "processing", severity = "fatal"):
+        """ Create a FHIR style failure response using an OperationOutcome. """
+        operation_outcome = open(os.path.join(self._fixture_path, "OperationOutcome.xml")).read()
+        operation_outcome = operation_outcome\
+            .replace("<code/>", f"<code>{code}</code>")\
+            .replace("<severity/>", f"<severity>{severity}</severity>")\
+            .replace("<diagnostics/>", f"<diagnostics>{diagnostics}</diagnostics>")
+
+        return http.HTTPResponse.make(response_code, operation_outcome.encode("UTF-8"), {"Content-Type": "application/fhir+xml"})
+
+    def _makeNTSRequest(self, path, fhir_version, body = None, accept_json = False):
+        """ Make a request to the NTS, using the proper authorization.
+            Return the response as a requests object, or False if the NTS cannot be used. """
+
+        if not self._support_nts:
+            return False
+
+        headers = {}
+        if accept_json:
+            headers["Accept"] = f"application/fhir+json; fhirVersion={fhir_version}.0"
+        else:
+            headers["Accept"] = f"application/fhir+xml; fhirVersion={fhir_version}.0"
+        if body:
+            headers["Content-Type"] = f"application/fhir+xml; fhirVersion={fhir_version}.0"
+
+        def request():
+            headers["Authorization"] = "Bearer " + self._nts_token
+            if body:
+                return requests.post(self.NTS_HOST + path, headers = headers, data = body)
+            else:
+                return requests.get(self.NTS_HOST + path, headers = headers)
+
+        if not self._nts_token:
+            # No NTS token yet, let's get one
+            self._refreshNTSToken()
+
+        if self._nts_token:
+            response = request()
+            if response.status_code == 403:
+                # NTS token is not valid. Let's try it again with a new one (just once so we don't get into an infinite loop).
+                self._refreshNTSToken()
+                response = request()
+            return response
+
+        return False
+
+    def _refreshNTSToken(self):
+        """ Retrieve an access token to perform NTS operations and set it to self._nts_token. If no valid token can be
+            retrieved, self._support_nts is set to False and further requests always return immediately. """
+
+        try:
+            _nts_user = os.environ["NTS_USER"]
+            _nts_pass = os.environ["NTS_PASS"]
+        except:
+            self._support_nts = False
+            ctx.log.info("Environment variables NTS_USER and NTS_PASS should be set to support the Nationale Terminologieserver")
+            return
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        body = {
+            "username"     : _nts_user,
+            "password"     : _nts_pass,
+            "client_id"    : "cli_client",
+            "client_secret": "",
+            "grant_type"   : "password"
+        }
+        response = requests.post(self.NTS_SCHEME + self.NTS_HOSTNAME + "/auth/realms/nictiz/protocol/openid-connect/token",
+            headers = headers, data = body)
+        if response.status_code == requests.codes.ok:
+            ctx.log.info("Retrieved an NTS access token")
+            self._nts_token = response.json()["access_token"]
+        else:
+            print("No NTS authorization. Disabling further requests to the Nationale Terminologieserver.")
+            ctx.log.info("No NTS authorization. Disabling further requests to the Nationale Terminologieserver.")
+            self._nts_token = None
+            self._support_nts = False
+
+addons = [CombinedTX()]

--- a/util/qaAutomation/CombinedTX/CombinedTX.py
+++ b/util/qaAutomation/CombinedTX/CombinedTX.py
@@ -46,7 +46,7 @@ class CombinedTX:
             os.environ["NTS_PASS"]
             self._support_nts = True
         except:
-            print("Environment variables NTS_USER and NTS_PASS are not set. Disabling support for the Nationale Terminologieserver")
+            print("\033[1;31mEnvironment variables NTS_USER and NTS_PASS are not set. Disabling support for the Nationale Terminologieserver\033[0m")
             ctx.log.info("Environment variables NTS_USER and NTS_PASS are not set. Disabling support for the Nationale Terminologieserver")
             self._support_nts = False
 
@@ -263,7 +263,7 @@ class CombinedTX:
             ctx.log.info("Retrieved an NTS access token")
             self._nts_token = response.json()["access_token"]
         else:
-            print("No NTS authorization. Disabling further requests to the Nationale Terminologieserver.")
+            print("\033[1;31mNo NTS authorization. Disabling further requests to the Nationale Terminologieserver.\033[0m")
             ctx.log.info("No NTS authorization. Disabling further requests to the Nationale Terminologieserver.")
             self._nts_token = None
             self._support_nts = False

--- a/util/qaAutomation/CombinedTX/fixtures/CapabilityStatement-v3.xml
+++ b/util/qaAutomation/CombinedTX/fixtures/CapabilityStatement-v3.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CapabilityStatement xmlns="http://hl7.org/fhir">
+  <id value="FhirServer"/>
+  <meta>
+  <tag>
+    <system value="http://hl7.org/fhir/v3/ObservationValue"/>
+    <code value="SUBSETTED"/>
+    <display value="Subsetted"/>
+  </tag>
+  </meta>
+  <name value="Combined Proxy TX server Conformance Statement"/>
+  <status value="active"/>
+  <kind value="instance"/>
+  <instantiates value="http://hl7.org/fhir/Conformance/terminology-server"/>
+  <software>
+    <name value="CombinedTX"/>
+  </software>
+  <fhirVersion value="3.0.2"/>
+  <format value="application/fhir+xml"/>
+  <rest>
+    <mode value="server"/>
+    <security>
+      <cors value="true"/>
+    </security>
+    <operation>
+      <name value="lookup"/>
+      <definition>
+        <reference value="http://hl7.org/fhir/OperationDefinition/ValueSet-lookup"/>
+      </definition>
+    </operation>
+    <operation>
+      <name value="validate-code"/>
+      <definition>
+        <reference value="http://hl7.org/fhir/OperationDefinition/Resource-validate"/>
+      </definition>
+    </operation>
+    <operation>
+      <name value="translate"/>
+      <definition>
+        <reference value="http://hl7.org/fhir/OperationDefinition/ConceptMap-translate"/>
+      </definition>
+    </operation>
+    <operation>
+      <name value="closure"/>
+      <definition>
+        <reference value="http://hl7.org/fhir/OperationDefinition/ConceptMap-closure"/>
+      </definition>
+    </operation>
+    <operation>
+      <name value="versions"/>
+      <definition>
+        <reference value="/OperationDefinition/fso-versions"/>
+      </definition>
+    </operation>
+  </rest>
+</CapabilityStatement>

--- a/util/qaAutomation/CombinedTX/fixtures/CapabilityStatement-v4.xml
+++ b/util/qaAutomation/CombinedTX/fixtures/CapabilityStatement-v4.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CapabilityStatement xmlns="http://hl7.org/fhir">
+  <id value="FhirServer"/>
+  <meta>
+  <tag>
+    <system value="http://hl7.org/fhir/v3/ObservationValue"/>
+    <code value="SUBSETTED"/>
+    <display value="Subsetted"/>
+  </tag>
+  </meta>
+  <name value="Combined Proxy TX server Conformance Statement"/>
+  <status value="active"/>
+  <kind value="instance"/>
+  <instantiates value="http://hl7.org/fhir/Conformance/terminology-server"/>
+  <software>
+    <name value="CombinedTX"/>
+  </software>
+  <fhirVersion value="4.0.1"/>
+  <format value="application/fhir+xml"/>
+  <rest>
+    <mode value="server"/>
+    <security>
+      <cors value="true"/>
+    </security>
+    <operation>
+      <name value="lookup"/>
+      <definition value="http://hl7.org/fhir/OperationDefinition/ValueSet-lookup"/>
+    </operation>
+    <operation>
+      <name value="validate-code"/>
+      <definition value="http://hl7.org/fhir/OperationDefinition/Resource-validate"/>
+    </operation>
+    <operation>
+      <name value="translate"/>
+      <definition value="http://hl7.org/fhir/OperationDefinition/ConceptMap-translate"/>
+    </operation>
+    <operation>
+      <name value="closure"/>
+      <definition value="http://hl7.org/fhir/OperationDefinition/ConceptMap-closure"/>
+    </operation>
+    <operation>
+      <name value="versions"/>
+      <definition value="/OperationDefinition/fso-versions"/>
+    </operation>
+  </rest>
+</CapabilityStatement>

--- a/util/qaAutomation/CombinedTX/fixtures/OperationOutcome.xml
+++ b/util/qaAutomation/CombinedTX/fixtures/OperationOutcome.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OperationOutcome xmlns="http://hl7.org/fhir">
+    <issue>
+        <severity/>
+        <code/>
+        <diagnostics/>
+    </issue>
+</OperationOutcome>

--- a/util/qaAutomation/CombinedTX/fixtures/Parameters-terminology_capabilities.xml
+++ b/util/qaAutomation/CombinedTX/fixtures/Parameters-terminology_capabilities.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Parameters xmlns="http://hl7.org/fhir">
+    <id value="FhirServer"/>
+    <parameter/>
+</Parameters>

--- a/util/qaAutomation/CombinedTX/fixtures/TerminologyCapabilities.xml
+++ b/util/qaAutomation/CombinedTX/fixtures/TerminologyCapabilities.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TerminologyCapabilities xmlns="http://hl7.org/fhir">
+    <id value="FhirServer"/>
+    <url value="http://fhir.healthintersections.com.au/open/metadata"/>
+    <name value="Combined Proxy TX server Conformance Statement"/>
+    <status value="active"/>
+    <description value="Conformance Statement for the combined terminology capabilities"/>
+    <codeSystem/>
+</TerminologyCapabilities>

--- a/util/qaAutomation/Dockerfile
+++ b/util/qaAutomation/Dockerfile
@@ -3,7 +3,8 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install wget
 RUN apt-get -y install openjdk-11-jre-headless
 RUN apt-get -y install git
-RUN apt-get -y install python3 python3-yaml
+RUN apt-get -y install python3 python3-yaml python3-requests
+RUN apt-get -y install mitmproxy
 RUN apt-get -y install nodejs npm
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb
 RUN apt-get update && apt-get -y install apt-transport-https && apt-get -y install dotnet-sdk-3.1 
@@ -30,6 +31,7 @@ COPY getresources.sh /scripts/getresources.sh
 COPY checktx.sh /scripts/checktx.sh
 COPY generatezibsnapshots.sh /scripts/generatezibsnapshots.sh
 COPY entrypoint.sh entrypoint.sh
+COPY CombinedTX /tools/CombinedTX
 RUN chmod +x entrypoint.sh
 RUN chmod +x /scripts/*.sh
 RUN dos2unix /scripts/getresources.sh /scripts/checktx.sh /scripts/generatezibsnapshots.sh entrypoint.sh

--- a/util/qaAutomation/README.md
+++ b/util/qaAutomation/README.md
@@ -1,26 +1,66 @@
 # QA tooling in Docker
 
-The QA tools are primarily specified in Github Action format. It would be good if the same specification can be re-used for local checks. There is a Docker based solution for this, called [Act by Nectos](https://github.com/nektos/act).
+Each of the QA tools for this project can be run manually, but to ease development, a Docker based solution is provided to execute the full stack (the same tools are executed on Github).  It consists of:
 
-However, at the moment of writing this solution doesn't support all the parts that we use. So instead we need to use a custom Docker setup that emulates the behaviour of the Github Actions specification. It consists of:
-
-* an image that includes:
-  * the same tooling for the checks on Github.
+* an image called "validate" that includes:
+  * the required tooling plus software, caches etc. needed to run it.
   * an entrypoint script that runs all the tools.
 * a docker-compose file to specify the container to run the image.
 
-The assumption is that, just like in a Github workflow, for each run a unique container will be created. This can be done using:
+The assumption is that (just like in a Github workflow) for each run a unique container will be created. In its most basic form, this can be done using:
 
-  > docker-compose run --rm validate
+  > docker-compose run [-f path/to/docker-compose.yml] --rm validate
 
-This will run the QA tools on the entire repository. If you just need to run the tools on the things that have been changed, you can add en extra parameter:
+The `-f` flag needs to be added when calling from any other dir than the current dir.
 
-  > docker-compose run --rm validate --changed-only.
+This command will check all the resources in the current repository, which can take quite some time. Ususally however, only the things that are new or changed or of interest to the developer (although a full run is of course advised when things are finished to see if they still mesh with what was already there). To do so, add the `--changed-only` flag at the end of the command:
 
-Note that in order to make the output more readable, the raw output of the FHIR Validator and snapshot generation will be suppressed. If something goes wrong, you can re-run the container with the `--debug` option to show the full output.
+  > docker-compose run [-f path/to/docker-compose.yml] --rm validate --changed-only
 
-If no terminology server checking needs to be done, the `--no-tx` option can be used.
+## (Re)building the image
 
-If a tool gets updated (for example, the HL7 Validator), it might be needed to rebuild the image. This can be done with the command:
+In order for the image to be used, it needs to be built first. This is done automatically when it is executed for the first time. However, if a tool gets updated (for example, the HL7 Validator), it might be needed to rebuild the image. This can be done with the command:
 
   > docker-compose build --no-cache
+
+This is quite a lengthy step. If there's just a change in one of the scripts, the `--no-cache` option can be omitted
+
+## Terminology checking and the Nationale Terminologieserver
+
+### Dual checking using the Nationale Terminologieserver
+A quite difficult part of validation is to pass all terminology checks, as this step is partially dependent on the terminology server used. Many of the zibs use Dutch translations, Dutch extensions and Dutch codesystems, which are not widely known on internation terminology server, resulting in false errors.
+
+The [Nationale Terminologieserver](https://terminologieserver.nl/fhir) is a partial solution to this problem, although it too misses some information that the default FHIR terminology server has, also resulting in false errors. To alleviate this problem, the Docker image contains a script that will use both the Nationale Terminologieserver _and_ the default FHIR terminology server as a fallback.
+
+Note: the FHIR Validator will report this as using `combined.tx` as the terminology server.
+
+To use this service, the user needs to have a valid login to the Nationale Terminologieserver. These credentials should be stored in the file "nts-credentials.env" in the format:
+
+```
+NTS_USER=xxx
+NTS_PASS=yyy
+```
+
+**WARNING:** This file is added to .gitignore so it doesn't get added to git. Don't commit the credentials to git, ever! 
+
+Which can then be added to the docker-compose command:
+
+  > docker-compose run [-f path/to/docker-compose.yml] --env-file path/to/nts-credentials.env --rm validate
+
+Note: instead of using this file, the environment variables `NTS_USER` and `NTS_PASS` may be set to the proper credentials.
+
+If this file is absent or empty or the credentials are invalid, only the fallback will be used.
+
+### Spying on the terminology server
+
+The dual check is implemented using a proxy server that relays requests to the actual terminology server(s). A bonus feature of this proxy is that it can be used to inspect all calls from the FHIR Validator. To do so, add the `-inspect-tx` flag afther the docker-compose command and point your web browser at `http://localhost:8081`.
+
+Note that, when using this flag, the workflow execution doesn't end automatically so that the proxy web interface can still be used after all tools have finished. The workflow should be manually stopped using Ctrl+C. (And yes, this is what the `--inspect-tx` flag _actually_ does; the proxy can be accessed without this flag as well, but it will shut down too quickly to be useful).
+
+### Disabling terminology checks
+The terminology server checks can also be disabled alltogether by using the `--no-tx` flag after the `docker-compose` command. 
+
+## Errors and debugging
+
+In order to make the output more readable, the raw output of the FHIR Validator and snapshot generation will be suppressed. If something goes wrong, you can re-run the container with the `--debug` option to show the full output.
+

--- a/util/qaAutomation/README.md
+++ b/util/qaAutomation/README.md
@@ -32,7 +32,7 @@ A quite difficult part of validation is to pass all terminology checks, as this 
 
 The [Nationale Terminologieserver](https://terminologieserver.nl/fhir) is a partial solution to this problem, although it too misses some information that the default FHIR terminology server has, also resulting in false errors. To alleviate this problem, the Docker image contains a script that will use both the Nationale Terminologieserver _and_ the default FHIR terminology server as a fallback.
 
-Note: the FHIR Validator will report this as using `combined.tx` as the terminology server.
+Note: the FHIR Validator will report this as using `v4.combined.tx` as the terminology server.
 
 To use this service, the user needs to have a valid login to the Nationale Terminologieserver. These credentials should be stored in the file "nts-credentials.env" in the format:
 
@@ -45,7 +45,7 @@ NTS_PASS=yyy
 
 Which can then be added to the docker-compose command:
 
-  > docker-compose run [-f path/to/docker-compose.yml] --env-file path/to/nts-credentials.env --rm validate
+  > docker-compose [-f path/to/docker-compose.yml] --env-file path/to/nts-credentials.env run --rm validate
 
 Note: instead of using this file, the environment variables `NTS_USER` and `NTS_PASS` may be set to the proper credentials.
 
@@ -53,7 +53,9 @@ If this file is absent or empty or the credentials are invalid, only the fallbac
 
 ### Spying on the terminology server
 
-The dual check is implemented using a proxy server that relays requests to the actual terminology server(s). A bonus feature of this proxy is that it can be used to inspect all calls from the FHIR Validator. To do so, add the `-inspect-tx` flag afther the docker-compose command and point your web browser at `http://localhost:8081`.
+The dual check is implemented using a proxy server that relays requests to the actual terminology server(s). A bonus feature of this proxy is that it can be used to inspect all calls from the FHIR Validator. To do so, add the option `-p 8081:8081` and the `-inspect-tx` flag to the docker-compose command and point your web browser at `http://localhost:8081`:
+
+  > docker-compose [-f path/to/docker-compose.yml] --env-file path/to/nts-credentials.env run --rm -p 8081:8081 validate --inspect-tx
 
 Note that, when using this flag, the workflow execution doesn't end automatically so that the proxy web interface can still be used after all tools have finished. The workflow should be manually stopped using Ctrl+C. (And yes, this is what the `--inspect-tx` flag _actually_ does; the proxy can be accessed without this flag as well, but it will shut down too quickly to be useful).
 

--- a/util/qaAutomation/checktx.sh
+++ b/util/qaAutomation/checktx.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 # Script to see if the terminology server is reachable
 
-tx_opt=""
-
 wget -O /dev/null --quiet tx.fhir.org
 if [ $? -ne 0 ]; then
-    tx_opt="-tx n/a"
+    disable_tx=1
 fi
 
 export tx_opt

--- a/util/qaAutomation/docker-compose.yml
+++ b/util/qaAutomation/docker-compose.yml
@@ -8,3 +8,8 @@ services:
         source: ../..
         target: /repo
         read_only: true
+    environment:
+      - NTS_USER
+      - NTS_PASS
+    ports:
+      - 8081:8081

--- a/util/qaAutomation/entrypoint.sh
+++ b/util/qaAutomation/entrypoint.sh
@@ -52,7 +52,7 @@ else
   # Start the proxy server to intelligently handle terminology requests
   set -m
   mitmweb --web-host "0.0.0.0" -s /tools/CombinedTX/CombinedTX.py -q &
-  echo "You can spy on the terminology server log at http://localhost:8081"
+  echo -e "\033[0;33mYou can spy on the terminology server log at http://localhost:8081\033[0m"
 fi
 
 source /scripts/getresources.sh


### PR DESCRIPTION
Heren,

Deze pull request is vooral ter info, ik verwacht niet echt een review. Maar deze fix maakt het mogelijk om de Nationale Terminologieserver te gebruiken voor validatie (alleen) met de Docker-straat. Je zou even naar de README kunnen kijken om te zien hoe het werkt, maar het komt vooral neer op het draaien van de batch-bestandjes. Verwacht geen wonderen, de NTS valt op het moment over hoofdlettergebruik dus er blijven suffe fouten naar voren komen. Maar het is weer een stapje verder.

De credentials voor de NTS zal ik via Teams delen.