### PR TITLE
TimeInterval

### DIFF
--- a/resources/nl-core/nl-core-TimeInterval.xml
+++ b/resources/nl-core/nl-core-TimeInterval.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="nl-core-TimeInterval"/>
+  <url value="http://nictiz.nl/fhir/StructureDefinition/nl-core-TimeInterval"/>
+  <name value="NlcoreTimeInterval"/>
+  <title value="nl core TimeInterval"/>
+  <status value="draft"/>
+  <publisher value="Nictiz"/>
+  <contact>
+    <name value="Nictiz"/>
+    <telecom>
+      <system value="email"/>
+      <value value="info@nictiz.nl"/>
+      <use value="work"/>
+    </telecom>
+  </contact>
+  <description value="A time interval indicates the time between two moments in time. Interval can be defined by a start time and end time , start time and duration or duration and end time."/>
+  <purpose value="A derived profile from [TimeInterval](http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval) to provide a version better suited for implementation purposes. This profile augments the base profile with elements found in the various use cases that have adopted the zib."/>
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+  <fhirVersion value="4.0.1"/>
+  <kind value="complex-type"/>
+  <abstract value="false"/>
+  <type value="Period"/>
+  <baseDefinition value="http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Period">
+      <path value="Period"/>
+      <alias value="nl-core-TimeInterval"/>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/nl-core/nl-core-VariableDosingRegimen.xml
+++ b/resources/nl-core/nl-core-VariableDosingRegimen.xml
@@ -117,6 +117,27 @@
         <comment value="Description" />
       </mapping>
     </element>
+    <element id="MedicationRequest.extension:periodOfUse">
+      <path value="MedicationRequest.extension" />
+      <sliceName value="periodOfUse" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period" />
+      </type>
+    </element>
+    <element id="MedicationRequest.extension:periodOfUse.value[x]">
+      <path value="MedicationRequest.extension.value[x]" />
+      <short value="PeriodOfUse" />
+      <definition value="**Start date**: This is the time at which the agreement was to take effect (or took effect or will take effect). This is the time at which the instructions for use in this agreement start. In the case of an agreement to discontinue use, this is the start date of the original medication agreement. The end date indicates from when the medication is to be discontinued.&#xD;&#xA;&#xD;&#xA;**End date**: The time at which the period of use ends (or ended or will end). In the case of an agreement to discontinue use, this is the time at which the medication is to be discontinued. To avoid confusion between 'to' and 'up to', the submission of time is always mandatory for the end date.&#xD;&#xA;&#xD;&#xA;With medication for an indefinite period only a start date is indicated." />
+      <alias value="Gebruiksperiode" />
+      <mapping>
+        <identity value="Medication-Process-v9-2-0-0" />
+        <map value="mp-dataelement920-635" />
+        <comment value="PeriodOfUse" />
+      </mapping>
+    </element>
     <element id="MedicationRequest.modifierExtension">
       <path value="MedicationRequest.modifierExtension" />
       <slicing>

--- a/resources/nl-core/searchparameter-period-of-use.xml
+++ b/resources/nl-core/searchparameter-period-of-use.xml
@@ -1,0 +1,27 @@
+<SearchParameter xmlns="http://hl7.org/fhir">
+    <id value="period-of-use"/>
+    <url value="http://nictiz.nl/fhir/SearchParameter/period-of-use"/>
+    <name value="PeriodOfUse"/>
+    <status value="draft"/>
+    <publisher value="Nictiz"/>
+    <contact>
+        <name value="Nictiz"/>
+        <telecom>
+            <system value="email"/>
+            <value value="info@nictiz.nl"/>
+            <use value="work"/>
+        </telecom>
+    </contact>
+    <description value="Search based on the PeriodOfUse concept captured in the TimeInterval.Period extension ('http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period') in the MedicationRequest and MedicationDispense resources.&#xA;&#xA;This SearchParameter searches the FHIR DataType Period in the TimeInterval.Period extension, which is added to profiles on MedicationRequest and MedicationDispense resources. This SearchParameter defines a date parameter search as described by the FHIR specification: https://hl7.org/fhir/r4/search.html#date. Servers are expected to take the TimeInterval-Duration extension (http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Duration) into account when processing a client&#39;s search. This means that either a Period.start AND Period.end or Period.start AND Duration or Period.end AND Duration is used to determine the search results. To illustrate the expected behavior: if a Period.start and a Duration is known, but not the Period.end, the Duration should be added to the Period.start date to calculate the Period.end. The calculated Period.end date is then used to determine the search results."/>
+    <purpose value="To search MedicationRequest and MedicationDispense resources on the value of the ext-TimeInterval-Period extension (http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period)."/>
+    <code value="period-of-use"/>
+    <base value="MedicationRequest"/>
+    <base value="MedicationDispense"/>
+    <type value="date"/>
+    <expression value="MedicationRequest.extension('http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period') | MedicationDispense.extension('http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period')"/>
+    <comparator value="eq"/>
+    <comparator value="le"/>
+    <comparator value="lt"/>
+    <comparator value="ge"/>
+    <comparator value="gt"/>
+</SearchParameter>

--- a/resources/zib/ext-TimeInterval.Duration.xml
+++ b/resources/zib/ext-TimeInterval.Duration.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ext-TimeInterval.Duration" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Duration" />
+  <name value="ExtTimeIntervalDuration" />
+  <title value="ext TimeInterval.Duration" />
+  <status value="draft" />
+  <publisher value="Nictiz"/>
+  <contact>
+    <name value="Nictiz"/>
+    <telecom>
+      <system value="email"/>
+      <value value="info@nictiz.nl"/>
+      <use value="work"/>
+    </telecom>
+  </contact>
+  <description value="The duration of the interval in appropriate units of time (e.g. days or hours, etc.)" />
+  <purpose value="This extension represents Duration of [TimeInterval](https://zibs.nl/wiki/TimeInterval-v1.0(2020EN))." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="zib-timeinterval-v1.0-2020EN" />
+    <uri value="https://zibs.nl/wiki/TimeInterval-v1.0(2020EN)" />
+    <name value="zib TimeInterval-v1.0(2020EN)" />
+  </mapping>
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="element" />
+    <expression value="Period" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefintion/ext-TimeInterval.Duration" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <short value="Duration" />
+      <definition value="The duration of the interval in appropriate units of time (e.g. days or hours, etc." />
+      <alias value="tijdsDuur" />
+      <type>
+        <code value="Quantity" />
+      </type>
+      <mapping>
+        <identity value="zib-timeinterval-v1.0-2020EN" />
+        <map value="NL-CM:20.3.4" />
+        <comment value="Duration" />
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib/ext-TimeInterval.Period.xml
+++ b/resources/zib/ext-TimeInterval.Period.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="ext-TimeInterval.Period" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period" />
+  <name value="ExtTimeIntervalPeriod" />
+  <title value="ext TimeInterval.Period" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="email" />
+      <value value="info@nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="An extension to provide the StartDateTime and EndDateTime of zib TimeInterval." />
+  <purpose value="This extension represents the startDateTime and endDateTime of Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) TimeInterval v1.0 (2020)](https://zibs.nl/wiki/TimeInterval-v1.0(2020EN)).&#xD;&#xA;&#xD;&#xA;Because some host resources natively support of the _Period_ datatype, it has been chosen not to make a complex extension representing all concepts of the zib. When the host resource supports the _Period_ datatype, the &lt;http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval&gt; datatype profile can be used on it, otherwise the current extension should be added. The &lt;http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Duration&gt; extension should be added on the same level as the element containing the _Period_." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <kind value="complex-type" />
+  <abstract value="false" />
+  <context>
+    <type value="fhirpath" />
+    <expression value="MedicationRequest" />
+  </context>
+  <context>
+    <type value="fhirpath" />
+    <expression value="MedicationDispense" />
+  </context>
+  <context>
+    <type value="fhirpath" />
+    <expression value="MediationStatement" />
+  </context>
+  <type value="Extension" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Extension.url">
+      <path value="Extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period" />
+    </element>
+    <element id="Extension.value[x]">
+      <path value="Extension.value[x]" />
+      <type>
+        <code value="Period" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval" />
+      </type>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/resources/zib/zib-AdministrationAgreement.xml
+++ b/resources/zib/zib-AdministrationAgreement.xml
@@ -86,6 +86,27 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-RenderedDosageInstruction" />
       </type>
     </element>
+    <element id="MedicationDispense.extension:periodOfUse">
+      <path value="MedicationDispense.extension" />
+      <sliceName value="periodOfUse" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period" />
+      </type>
+    </element>
+    <element id="MedicationDispense.extension:periodOfUse.value[x]">
+      <path value="MedicationDispense.extension.value[x]" />
+      <short value="PeriodOfUse" />
+      <definition value="**Start date**: This is the time at which the agreement was to take effect (or took effect or will take effect). This is the time at which the instructions for use in this agreement start. In the case of an agreement to discontinue use, this is the start date of the original administration agreement. The end date indicates from when the medication is to be discontinued.&#xD;&#xA;&#xD;&#xA;**Duration**: The intended duration of use. E.g. 5 days or 8 weeks. It is not allowed to indicate the duration in months, because different months have a variable duration in days.&#xD;&#xA;&#xD;&#xA;**End date**: The time at which the period of use ends (or ended or will end). In the case of an agreement to discontinue use, this is the time at which the medication is to be discontinued. To avoid confusion between 'to' and 'up to', the submission of time is always mandatory for the end date.&#xD;&#xA;&#xD;&#xA;With medication for an indefinite period only a start date is indicated." />
+      <alias value="Gebruiksperiode" />
+      <mapping>
+        <identity value="zib-administrationagreement-v1.0.3-2020EN" />
+        <map value="NL-CM:9.8.22660" />
+        <comment value="PeriodOfUse" />
+      </mapping>
+    </element>
     <element id="MedicationDispense.modifierExtension">
       <path value="MedicationDispense.modifierExtension" />
       <slicing>

--- a/resources/zib/zib-DispenseRequest.xml
+++ b/resources/zib/zib-DispenseRequest.xml
@@ -191,6 +191,21 @@
         <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-DispenseRequest.DispenseLocation" />
       </type>
     </element>
+    <element id="MedicationRequest.dispenseRequest.validityPeriod">
+      <path value="MedicationRequest.dispenseRequest.validityPeriod" />
+      <short value="PeriodOfUse" />
+      <definition value="During the approved period of use, the pharmacist has permission to dispense medicine so that the patient has a sufficient amount of medication. In many cases, the approved period of use can be described by only an end date: the approved end date of use." />
+      <alias value="Verbruiksperiode" />
+      <type>
+        <code value="Period" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval" />
+      </type>
+      <mapping>
+        <identity value="zib-dispenserequest-v1.0.3-2020EN" />
+        <map value="NL-CM:9.10.20062" />
+        <comment value="PeriodOfUse" />
+      </mapping>
+    </element>
     <element id="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed">
       <path value="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed" />
       <short value="NumberOfRefills" />

--- a/resources/zib/zib-MedicationAgreement.xml
+++ b/resources/zib/zib-MedicationAgreement.xml
@@ -84,6 +84,27 @@
         <comment value="Description" />
       </mapping>
     </element>
+    <element id="MedicationRequest.extension:periodOfUse">
+      <path value="MedicationRequest.extension" />
+      <sliceName value="periodOfUse" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Period" />
+      </type>
+    </element>
+    <element id="MedicationRequest.extension:periodOfUse.value[x]">
+      <path value="MedicationRequest.extension.value[x]" />
+      <short value="PeriodOfUse" />
+      <definition value="**Start date**: This is the time at which the agreement was to take effect (or took effect or will take effect). This is the time at which the instructions for use in this agreement start. In the case of an agreement to discontinue use, this is the start date of the original medication agreement. The end date indicates from when the medication is to be discontinued.&#xD;&#xA;&#xD;&#xA;**Duration**: The intended duration of use. E.g. 5 days or 8 weeks. It is not allowed to indicate the duration in months, because different months have a variable duration in days.&#xD;&#xA;&#xD;&#xA;**End date**: The time at which the period of use ends (or ended or will end). In the case of an agreement to discontinue use, this is the time at which the medication is to be discontinued. To avoid confusion between 'to' and 'up to', the submission of time is always mandatory for the end date.&#xD;&#xA;&#xD;&#xA;With medication for an indefinite period only a start date is indicated." />
+      <alias value="Gebruiksperiode" />
+      <mapping>
+        <identity value="zib-medicationagreement-v1.2-2020EN" />
+        <map value="NL-CM:9.6.19936" />
+        <comment value="PeriodOfUse" />
+      </mapping>
+    </element>
     <element id="MedicationRequest.modifierExtension">
       <path value="MedicationRequest.modifierExtension" />
       <slicing>

--- a/resources/zib/zib-MedicationUse2.xml
+++ b/resources/zib/zib-MedicationUse2.xml
@@ -217,6 +217,22 @@
         <rules value="open" />
       </slicing>
     </element>
+    <element id="MedicationStatement.effective[x]:effectivePeriod">
+      <path value="MedicationStatement.effective[x]" />
+      <sliceName value="effectivePeriod" />
+      <short value="PeriodOfUse" />
+      <definition value="Medication use can be recorded for a certain moment or over a certain period. Thus, medication use can be recorded multiple times during the use of medication. The usage period is the period or moment over which the data is recorded.&#xA;**Start date:** This is the time at which the agreement was to take effect (or took effect or will take effect). &#xA;**End date:** The time at which the period of use ends (or ended or will end). To avoid confusion between 'to' and 'up to', the submission of time is always mandatory for the end date." />
+      <alias value="Gebruiksperiode" />
+      <type>
+        <code value="Period" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval" />
+      </type>
+      <mapping>
+        <identity value="zib-medicationuse2-v1.1.1-2020EN" />
+        <map value="NL-CM:9.11.22663" />
+        <comment value="PeriodOfUse" />
+      </mapping>
+    </element>
     <element id="MedicationStatement.dateAsserted">
       <path value="MedicationStatement.dateAsserted" />
       <short value="MedicationUseDateTime" />

--- a/resources/zib/zib-TimeInterval.xml
+++ b/resources/zib/zib-TimeInterval.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="zib-TimeInterval"/>
+  <url value="http://nictiz.nl/fhir/StructureDefinition/zib-TimeInterval"/>
+  <name value="ZibTimeInterval"/>
+  <title value="zib TimeInterval"/>
+  <status value="draft"/>
+  <publisher value="Nictiz"/>
+  <contact>
+    <name value="Nictiz"/>
+    <telecom>
+      <system value="email"/>
+      <value value="info@nictiz.nl"/>
+      <use value="work"/>
+    </telecom>
+  </contact>
+  <description value="A time interval indicates the time between two moments in time. Interval can be defined by a start time and end time , start time and duration or duration and end time."/>
+  <purpose value="This Period datatype represents the Dutch [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) TimeInterval-v1.0 (2020)]( https://zibs.nl/wiki/TimeInterval-v1.0(2020EN))."/>
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
+  <fhirVersion value="4.0.1"/>
+  <mapping>
+    <identity value="zib-timeinterval-v1.0-2020EN"/>
+    <uri value="https://zibs.nl/wiki/TimeInterval-v1.0(2020EN)"/>
+    <name value="zib TimeInterval-v1.0(2020EN)"/>
+  </mapping>
+  <kind value="complex-type"/>
+  <abstract value="true"/>
+  <type value="Period"/>
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Period"/>
+  <derivation value="constraint"/>
+  <differential>
+    <element id="Period.extension">
+      <path value="Period.extension"/>
+      <slicing>
+        <discriminator>
+          <type value="value"/>
+          <path value="url"/>
+        </discriminator>
+        <rules value="open"/>
+      </slicing>
+    </element>
+    <element id="Period.extension:duration">
+      <path value="Period.extension"/>
+      <sliceName value="duration"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-TimeInterval.Duration"/>
+      </type>
+    </element>
+    <element id="Period.extension:duration.value[x]">
+      <path value="Period.extension.value[x]"/>
+      <short value="Duration"/>
+      <definition value="The duration of the interval in appropriate units of time (e.g. days or hours, etc."/>
+      <alias value="tijdsDuur"/>
+      <mapping>
+        <identity value="zib-timeinterval-v1.0-2020EN"/>
+        <map value="NL-CM:20.3.4"/>
+        <comment value="Duration"/>
+      </mapping>
+    </element>
+    <element id="Period.start">
+      <path value="Period.start"/>
+      <short value="startDateTime"/>
+      <definition value="The start date and time of the interval"/>
+      <alias value="startDatumTijd"/>
+      <mapping>
+        <identity value="zib-timeinterval-v1.0-2020EN"/>
+        <map value="NL-CM:20.3.2"/>
+        <comment value="startDateTime"/>
+      </mapping>
+    </element>
+    <element id="Period.end">
+      <path value="Period.end"/>
+      <short value="endDateTime"/>
+      <definition value="The end date and time of the interval"/>
+      <alias value="eindDatumTijd"/>
+      <mapping>
+        <identity value="zib-timeinterval-v1.0-2020EN"/>
+        <map value="NL-CM:20.3.3"/>
+        <comment value="endDateTime"/>
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>


### PR DESCRIPTION
Trying to make the current situation of zib-TimeInterval visible.

The profiles either reference extension `ext-TimeInterval.Period` or (if the resource allows a Period) Period datatype profile `zib-TimeInterval`. `ext-TimeInterval.Period` is an extension with a valuePeriod which has `zib-TimeInterval` placed on it.

`zib-TimeInterval` contains extension `ext-TimeInterval.Duration`.

When using `zib-TimeInterval`, at the moment it does not seem possible to leave out `ext-TimeInterval.Duration`.

Previously (in the version that is currently at the Validatieraad), the 'Duration' and 'Period' extensions were added next to each other (or only the Duration extension was added when a Period element was already present) within the various profiles instead of nested. This situation would allow more 'control'.

Previously 2 (in the version that is currently at the Validatieraad), `ext-TimeInterval.Duration` had the comment:

> Please note that when the zib concept Duration is known together with the zib concept startDateTime or a endDateTime, it should be communicated using a calculated Period. This element SHALL only be used if a Duration is known when neither startDateTime and endDateTime are known.

This has been removed, we could re-add the text using 'SHOULD'.

(There is an nl-core-TimeInterval profile, but it isn't referenced from other nl-core-profiles. This is something that should be fixed, so I left it out of this comparison.)