### PR TITLE
#231: Fix for ConceptMap used in zib-ContactInformation-EmailAdresses…

### DIFF
--- a/resources/zib/terminology/EmailSoortCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20200901000000.xml
+++ b/resources/zib/terminology/EmailSoortCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20200901000000.xml
@@ -1,0 +1,86 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="EmailSoortCodelijst"/>
+   <title value="EmailSoortCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="EmailSoortCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
+         <concept>
+            <code value="HP"/>
+            <display value="Primary Home"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Primary Home"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Privé e-mailadres"/>
+            </designation>
+         </concept>
+         <concept>
+            <code value="WP"/>
+            <display value="Work Place"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Work Place"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Zakelijk e-mailadres"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
+</ValueSet>

--- a/resources/zib/terminology/conceptmap-EmailSoortCodelijst-to-ContactInformation-EmailAddressesUse.xml
+++ b/resources/zib/terminology/conceptmap-EmailSoortCodelijst-to-ContactInformation-EmailAddressesUse.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ConceptMap xmlns="http://hl7.org/fhir">
-    <id value="NummerSoortCodelijst-to-ContactInformation-EmailAddressesUse" />
+    <id value="EmailSoortCodelijst-to-ContactInformation-EmailAddressesUse" />
     <extension url="http://hl7.org/fhir/StructureDefinition/concept-bidirectional">
         <valueBoolean value="true"/>
     </extension>
-    <url value="http://nictiz.nl/fhir/ConceptMap/NummerSoortCodelijst-to-ContactInformation-EmailAddressesUse" />
-    <name value="NummerSoortCodelijst_to_ContactInformation_EmailAddressesUse" />
-    <title value="NummerSoortCodelijst to ContactInformation-EmailAddressesUse" />
+    <url value="http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactInformation-EmailAddressesUse" />
+    <name value="EmailSoortCodelijst_to_ContactInformation_EmailAddressesUse" />
+    <title value="EmailSoortCodelijst to ContactInformation-EmailAddressesUse" />
     <status value="active" />
     <publisher value="Nictiz" />
     <contact>
@@ -17,12 +17,11 @@
             <use value="work" />
         </telecom>
     </contact>
-    <description value="Maps NumberType codes as found in [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) ContactInformation v1.2(2020)](https://zibs.nl/wiki/ContactInformation-v1.2(2020EN)) to `ContactPoint.use` codes as found in FHIR R4" />
+    <description value="Maps EmailAddressType codes as found in [zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) ContactInformation v1.2(2020)](https://zibs.nl/wiki/ContactInformation-v1.2(2020EN)) to `ContactPoint.use` codes as found in FHIR R4" />
     <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise."/>
-    <sourceCanonical value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.2--20200901000000"/>
+    <sourceCanonical value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.20.6.3--20200901000000"/>
     <targetCanonical value="http://nictiz.nl/fhir/ValueSet/ContactInformation-EmailAddressesUse"/>
     <group>
-        <!-- 2.16.840.1.113883.5.1119 -->
         <source value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
         <target value="http://hl7.org/fhir/contact-point-use"/>
         <element>

--- a/resources/zib/zib-ContactInformation-EmailAddresses.xml
+++ b/resources/zib/zib-ContactInformation-EmailAddresses.xml
@@ -65,7 +65,7 @@
         <description value="Use ConceptMap NummerSoortCodelijst-to-ContactInformation-EmailAddressesUse to translate terminology from the functional model to profile terminology in ValueSet ContactInformation-EmailAddressesUse." />
         <valueSet value="http://nictiz.nl/fhir/ValueSet/ContactInformation-EmailAddressesUse">
           <extension url="http://hl7.org/fhir/StructureDefinition/11179-permitted-value-conceptmap">
-            <valueCanonical value="http://nictiz.nl/fhir/ConceptMap/NummerSoortCodelijst-to-ContactInformation-EmailAddressesUse" />
+            <valueCanonical value="http://nictiz.nl/fhir/ConceptMap/EmailSoortCodelijst-to-ContactInformation-EmailAddressesUse" />
           </extension>
         </valueSet>
       </binding>


### PR DESCRIPTION
… to use the EmailSoortCodelijst rather than the NummerSoortCodelijst.