### PR TITLE
QA edit

### DIFF
--- a/.github/workflows/qa-all.yml
+++ b/.github/workflows/qa-all.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Validate zib profiles
         id: validate-zib-profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -45,7 +45,7 @@ jobs:
         continue-on-error: true
       - name: Validate zib extensions
         id: validate-zib-extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -57,7 +57,7 @@ jobs:
         continue-on-error: true
       - name: Validate nl-core profiles
         id: validate-nl-core-profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true
       - name: Validate nl-core extensions
         id: validate-nl-core-extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -81,7 +81,7 @@ jobs:
         continue-on-error: true
       - name: Validate other profiles
         id: validate-other-profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -93,7 +93,7 @@ jobs:
         continue-on-error: true
       - name: Validate ConceptMaps
         id: validate-conceptmaps
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -105,7 +105,7 @@ jobs:
         continue-on-error: true
       - name: Validate other terminology
         id: validate-other-terminology
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -116,7 +116,7 @@ jobs:
         continue-on-error: true
       - name: Validate SearchParameters
         id: validate-other-searchparameters
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -127,7 +127,7 @@ jobs:
         continue-on-error: true
       - name: Validate examples
         id: validate-examples
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/

--- a/.github/workflows/qa-changed.yml
+++ b/.github/workflows/qa-changed.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Validate zib profiles
         id: validate-zib-profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -47,7 +47,7 @@ jobs:
         continue-on-error: true
       - name: Validate zib extensions
         id: validate-zib-extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -58,7 +58,7 @@ jobs:
         continue-on-error: true
       - name: Validate nl-core profiles
         id: validate-nl-core-profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true
       - name: Validate nl-core extensions
         id: validate-nl-core-extensions
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
       - name: Validate other profiles
         id: validate-other-profiles
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -91,7 +91,7 @@ jobs:
         continue-on-error: true
       - name: Validate ConceptMaps
         id: validate-conceptmaps
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: true
       - name: Validate other terminology
         id: validate-other-terminology
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -112,7 +112,7 @@ jobs:
         continue-on-error: true
       - name: Validate SearchParameters
         id: validate-other-searchparameters
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/ qa/
@@ -122,7 +122,7 @@ jobs:
         continue-on-error: true
       - name: Validate examples
         id: validate-examples
-        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.19
+        uses: pieter-edelman-nictiz/hl7-fhir-validator-action@v0.22
         with:
           version: "4.0"
           ig: resources/

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
@@ -85,7 +85,7 @@
         <key value="sd-pg-03" />
         <severity value="error" />
         <human value="If mapping.map exists and the mapping is not implicit and the element is not the root element, definition should exist." />
-        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.id.indexOf('.') != -1) implies definition.exists()" />
+        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and id.indexOf('.') != -1 and mapping.select(map.endsWith('.1').not()).anyTrue()) implies definition.exists()" />
         <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
       </constraint>
       <constraint>

--- a/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
+++ b/qa/ProfilingGuidelinesR4-StructureDefinitions-Zib.xml
@@ -85,7 +85,7 @@
         <key value="sd-pg-03" />
         <severity value="error" />
         <human value="If mapping.map exists and the mapping is not implicit and the element is not the root element, definition should exist." />
-        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.indexOf('.') != -1) implies definition.exists()" />
+        <expression value="(mapping.select(map.exists() and comment.contains(' (implicit, main mapping is on ').not()).anyTrue() and $this.id.indexOf('.') != -1) implies definition.exists()" />
         <source value="https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4" />
       </constraint>
       <constraint>


### PR DESCRIPTION
Updates workflow version

GitHub QA tooling failed a check where both a FHIR root element with a zib root concept mapped and other elements with a zib root concept mapped required a .description, which should not be the case.

First, I noticed a discrepancy between Docker and GitHub QA tooling - the first one passed and the latter failed, reacting differently to what turned out to be an invalid expression. Adding the 'id' part to the expression fixed this. The FHIR root with a zib root concept error now disappeared in GitHub, while Docker now showed the 'other concepts with a zib root concept mapped' error aswell.

The second bug is fixed by adding a selection based on mapping map (ending on '.1') to the expression. The original selector (no '.' in path) is kept in place to account for Medication zibs, which are the only zibs that have root concepts that do not end with '.1'.