### PR TITLE
Updated Resource.id to match filename thus avoiding duplicates

### DIFF
--- a/examples/nl-core-PharmaceuticalProduct-randomCode-invalid.xml
+++ b/examples/nl-core-PharmaceuticalProduct-randomCode-invalid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Medication xmlns="http://hl7.org/fhir">
-   <id value="nl-core-PharmaceuticalProduct-02"/>
+   <id value="nl-core-PharmaceuticalProduct-randomCode-invalid"/>
    <meta>
       <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-PharmaceuticalProduct"/>
    </meta>

--- a/examples/nl-core-Vaccination-03-PharmaceuticalProduct-01.xml
+++ b/examples/nl-core-Vaccination-03-PharmaceuticalProduct-01.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Medication xmlns="http://hl7.org/fhir">
-   <id value="nl-core-PharmaceuticalProduct-01"/>
+   <id value="nl-core-Vaccination-03-PharmaceuticalProduct-01"/>
    <meta>
       <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-PharmaceuticalProduct"/>
    </meta>

--- a/known-issues.yml
+++ b/known-issues.yml
@@ -532,6 +532,15 @@ nl-core-Mobility-*:
       - message: Slicing cannot be evaluated
         reason: To check slicing in instances, the referenced resources need to be inspected, but this is not supported by the HL7 Validator.
 
+nl-core-PharmaceuticalProduct-randomCode-invalid:
+  ignored issues:
+    Medication.code:
+      - message: None of the codings provided are in the value set 'ProductCodeCodelijsten'
+        reason: This is an example of a resource that purposely contains an invalid code system and code
+    Medication.code.coding[0]:
+      - message: Code System URI 'urn:oid:2.16.840.1.113883.2.4.4.9999' is unknown so the code cannot be validated
+        reason: This is an example of a resource that purposely contains an invalid code system and code
+        
 nl-core-VisualFunction.VisualAid-*:
   ignored issues:
     DeviceUseStatement.reasonReference[*]:

--- a/resources/nl-core/nl-core-MedicalDevice.xml
+++ b/resources/nl-core/nl-core-MedicalDevice.xml
@@ -80,8 +80,8 @@
       <sliceName value="procedure" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinitions/nl-core-Procedure-event" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinitions/nl-core-Procedure-request" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Procedure-event" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Procedure-request" />
       </type>
     </element>
     <element id="DeviceUseStatement.device">


### PR DESCRIPTION
Because of the duplicate Resource.id for the same resources, this leads to issues in the IG Publisher (and potentially other places)