### PR TITLE
Fix reference to nl-core in zib

### DIFF
--- a/resources/nl-core/nl-core-AdvanceDirective.xml
+++ b/resources/nl-core/nl-core-AdvanceDirective.xml
@@ -28,6 +28,29 @@
       <path value="Consent" />
       <alias value="nl-core-AdvanceDirective" />
     </element>
+    <element id="Consent.extension">
+      <path value="Consent.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="0" />
+    </element>
+    <element id="Consent.extension:disorder">
+      <path value="Consent.extension" />
+      <sliceName value="disorder" />
+      <min value="0" />
+    </element>
+    <element id="Consent.extension:disorder.value[x]">
+      <path value="Consent.extension.value[x]" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Problem" />
+      </type>
+    </element>
     <element id="Consent.patient">
       <path value="Consent.patient" />
       <type>

--- a/resources/zib/ext-AdvanceDirective.Disorder.xml
+++ b/resources/zib/ext-AdvanceDirective.Disorder.xml
@@ -44,7 +44,7 @@
       <alias value="Aandoening" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Problem" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem" />
       </type>
       <mapping>
         <identity value="zib-advancedirective-v3.1.1-2020EN" />


### PR DESCRIPTION
Enige geval dat ik kon vinden.

In de zib-dir gezocht op "targetProfile" en i.c.m. "nl-core" was dit de enige die naar boven kwam.