### PR TITLE
Nl core vaccination event remove zorgaanbieder reference and add documentation

### DIFF
--- a/resources/nl-core/nl-core-Vaccination-event.xml
+++ b/resources/nl-core/nl-core-Vaccination-event.xml
@@ -92,7 +92,6 @@
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
         <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization" />
       </type>
     </element>
     <element id="Immunization.reasonCode">

--- a/resources/nl-core/nl-core-Vaccination-event.xml
+++ b/resources/nl-core/nl-core-Vaccination-event.xml
@@ -31,7 +31,7 @@
   <differential>
     <element id="Immunization">
       <path value="Immunization" />
-      <comment value="The zib Vaccination is mapped to this Immunization profile and a profile on ImmunizationRecommendation (&lt;http://nictiz.nl/fhir/StructureDefinition/nl-core-Vaccination-request&gt;). All administered vaccinations are covered using this Immunization profile, while all planned vaccinations are covered in the ImmunizationRecommendation profile. &#xD;&#xA;&#xD;&#xA;Please note that, contrary to the related zib concepts, `.vaccineCode` and `.occurrence[x]` are mandatory in FHIR and need to be recorded to exchange Immunization resources." />
+      <comment value="The zib Vaccination is mapped to this Immunization profile and a profile on ImmunizationRecommendation (&lt;http://nictiz.nl/fhir/StructureDefinition/nl-core-Vaccination-request&gt;). All administered vaccinations are covered using this Immunization profile, while all planned vaccinations are covered in the ImmunizationRecommendation profile. &#xD;&#xA;&#xD;&#xA;This Immunization profile contains components that are not part of the current zib Vaccination. These components are added to this profile as they are likely to a part of a the future zib Vaccination. &#xD;&#xA;&#xD;&#xA;Please note that, contrary to the related zib concepts, `.vaccineCode` and `.occurrence[x]` are mandatory in FHIR and need to be recorded to exchange Immunization resources." />
       <alias value="nl-core-Vaccination-event" />
     </element>
     <element id="Immunization.extension">


### PR DESCRIPTION
The reference to the nl core healthcareprovider organisation has been removed. With the removal of the reference the profile now reflects the zib2020 Vaccination correctly.

Documentation is also added to the profile to notify the implementer about the additional components this profile contains. These components might otherwise seem out of place if there relation with a future zib Vaccination is not mentioned
