### PR TITLE
Refresh terminology

### DIFF
--- a/resources/zib/terminology/AdemhalingScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1--20200901000000.xml
+++ b/resources/zib/terminology/AdemhalingScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1--20200901000000.xml
@@ -1,71 +1,72 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+02:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="AdemhalingScoreCodelijst"/>
-    <title value="AdemhalingScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="AdemhalingScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="http://loinc.org"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Niet op eigen kracht ademen"/>
-                </extension>
-                <code value="LA6725-1"/>
-                <display value="Not breathing"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Zwak, onregelmatig of hijgerig ademhalen"/>
-                </extension>
-                <code value="LA6726-9"/>
-                <display value="Weak cry; may sound like whimpering, slow or irregular breathing"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="2"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Flink huilen en goed doorademen"/>
-                </extension>
-                <code value="LA6727-7"/>
-                <display value="Good, strong cry; normal rate and effort of breathing"/>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.1"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="AdemhalingScoreCodelijst"/>
+   <title value="AdemhalingScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="AdemhalingScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="http://loinc.org"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Niet op eigen kracht ademen"/>
+            </extension>
+            <code value="LA6725-1"/>
+            <display value="Not breathing"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Zwak, onregelmatig of hijgerig ademhalen"/>
+            </extension>
+            <code value="LA6726-9"/>
+            <display value="Weak cry; may sound like whimpering, slow or irregular breathing"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="2"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Flink huilen en goed doorademen"/>
+            </extension>
+            <code value="LA6727-7"/>
+            <display value="Good, strong cry; normal rate and effort of breathing"/>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/HartslagScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2--20200901000000.xml
+++ b/resources/zib/terminology/HartslagScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2--20200901000000.xml
@@ -1,71 +1,72 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+02:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="HartslagScoreCodelijst"/>
-    <title value="HartslagScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="HartslagScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="http://loinc.org"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Geen hartslag, of een onhoorbare hartslag"/>
-                </extension>
-                <code value="LA6716-0"/>
-                <display value="No heart rate"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Een hartslag van minder dan 100 slagen per minuut"/>
-                </extension>
-                <code value="LA6717-8"/>
-                <display value="Fewer than 100 beats per minute"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="2"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Een hartslag van meer dan 100 slagen per minuut"/>
-                </extension>
-                <code value="LA6718-6"/>
-                <display value="At least 100 beats per minute"/>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.2"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="HartslagScoreCodelijst"/>
+   <title value="HartslagScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="HartslagScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="http://loinc.org"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Geen hartslag, of een onhoorbare hartslag"/>
+            </extension>
+            <code value="LA6716-0"/>
+            <display value="No heart rate"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Een hartslag van minder dan 100 slagen per minuut"/>
+            </extension>
+            <code value="LA6717-8"/>
+            <display value="Fewer than 100 beats per minute"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="2"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Een hartslag van meer dan 100 slagen per minuut"/>
+            </extension>
+            <code value="LA6718-6"/>
+            <display value="At least 100 beats per minute"/>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/HuidskleurScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4--20200901000000.xml
+++ b/resources/zib/terminology/HuidskleurScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4--20200901000000.xml
@@ -1,71 +1,72 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+02:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="HuidskleurScoreCodelijst"/>
-    <title value="HuidskleurScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="HuidskleurScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="http://loinc.org"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Een bleke of blauwe huidskleur"/>
-                </extension>
-                <code value="LA6722-8"/>
-                <display value="The baby's whole body is completely bluish-gray or pale"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Roze lijfje, maar blauwachtige armen en benen"/>
-                </extension>
-                <code value="LA6723-6"/>
-                <display value="Good color in body with bluish hands or feet"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="2"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Mooie roze huidskleur"/>
-                </extension>
-                <code value="LA6724-4"/>
-                <display value="Good color all over"/>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.4"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="HuidskleurScoreCodelijst"/>
+   <title value="HuidskleurScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="HuidskleurScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="http://loinc.org"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Een bleke of blauwe huidskleur"/>
+            </extension>
+            <code value="LA6722-8"/>
+            <display value="The baby's whole body is completely bluish-gray or pale"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Roze lijfje, maar blauwachtige armen en benen"/>
+            </extension>
+            <code value="LA6723-6"/>
+            <display value="Good color in body with bluish hands or feet"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="2"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Mooie roze huidskleur"/>
+            </extension>
+            <code value="LA6724-4"/>
+            <display value="Good color all over"/>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/LateraliteitCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.20.2--20200901000000.xml
+++ b/resources/zib/terminology/LateraliteitCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.20.2--20200901000000.xml
@@ -43,7 +43,7 @@
                <valueString value="Links"/>
             </extension>
             <code value="7771000"/>
-                <display value="Left"/>
+            <display value="links"/>
             <designation>
                <language value="en-US"/>
                <use>
@@ -68,7 +68,7 @@
                <valueString value="Rechts"/>
             </extension>
             <code value="24028007"/>
-                <display value="Right"/>
+            <display value="rechts"/>
             <designation>
                <language value="en-US"/>
                <use>

--- a/resources/zib/terminology/OntwikkelingMotoriekCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3--20200901000000.xml
+++ b/resources/zib/terminology/OntwikkelingMotoriekCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3--20200901000000.xml
@@ -1,167 +1,168 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="OntwikkelingMotoriekCodelijst"/>
-    <title value="OntwikkelingMotoriekCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="OntwikkelingMotoriekCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Draait van buik naar rug en andersom"/>
-                </extension>
-                <code value="282632008"/>
-                <display value="in staat zich om te rollen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to roll over"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat zich om te rollen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan kruipen"/>
-                </extension>
-                <code value="282607006"/>
-                <display value="in staat om te kruipen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to crawl"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om te kruipen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan zelfstandig zitten"/>
-                </extension>
-                <code value="302040002"/>
-                <display value="in staat om zonder steun te zitten"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to sit unsupported"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om zonder steun te zitten"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Trekt zich op tot staan"/>
-                </extension>
-                <code value="282888002"/>
-                <display value="in staat om zich op te trekken tot staan vanuit zithouding"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to pull to standing from sitting"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om zich op te trekken tot staan vanuit zithouding"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan zonder hulp lopen"/>
-                </extension>
-                <code value="165245003"/>
-                <display value="in staat om zelfstandig te lopen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Independent walking"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om zelfstandig te lopen"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.3"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="OntwikkelingMotoriekCodelijst"/>
+   <title value="OntwikkelingMotoriekCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="OntwikkelingMotoriekCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Draait van buik naar rug en andersom"/>
+            </extension>
+            <code value="282632008"/>
+            <display value="in staat zich om te rollen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to roll over"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat zich om te rollen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan kruipen"/>
+            </extension>
+            <code value="282607006"/>
+            <display value="in staat om te kruipen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to crawl"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om te kruipen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan zelfstandig zitten"/>
+            </extension>
+            <code value="302040002"/>
+            <display value="in staat om zonder steun te zitten"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to sit unsupported"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om zonder steun te zitten"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Trekt zich op tot staan"/>
+            </extension>
+            <code value="282888002"/>
+            <display value="in staat om zich op te trekken tot staan vanuit zithouding"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to pull to standing from sitting"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om zich op te trekken tot staan vanuit zithouding"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan zonder hulp lopen"/>
+            </extension>
+            <code value="165245003"/>
+            <display value="in staat om zelfstandig te lopen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Independent walking"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om zelfstandig te lopen"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/OntwikkelingSociaalCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4--20200901000000.xml
+++ b/resources/zib/terminology/OntwikkelingSociaalCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4--20200901000000.xml
@@ -1,167 +1,168 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="OntwikkelingSociaalCodelijst"/>
-    <title value="OntwikkelingSociaalCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="OntwikkelingSociaalCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Lacht terug"/>
-                </extension>
-                <code value="47041000146107"/>
-                <display value="glimlacht terug"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Smiles back"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="glimlacht terug"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Speelt geven en nemen"/>
-                </extension>
-                <code value="26281000146106"/>
-                <display value="in staat om te geven en nemen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to give and take"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om te geven en nemen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan spelen met andere kinderen"/>
-                </extension>
-                <code value="26301000146107"/>
-                <display value="in staat om te spelen met andere kinderen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to play with other children"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om te spelen met andere kinderen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan vrienden maken"/>
-                </extension>
-                <code value="26291000146108"/>
-                <display value="in staat om vrienden te maken"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to make friends"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om vrienden te maken"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan zich inleven in anderen"/>
-                </extension>
-                <code value="26321000146104"/>
-                <display value="in staat om zich in te leven in anderen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to show empathy"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om zich in te leven in anderen"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.4"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="OntwikkelingSociaalCodelijst"/>
+   <title value="OntwikkelingSociaalCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="OntwikkelingSociaalCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Lacht terug"/>
+            </extension>
+            <code value="47041000146107"/>
+            <display value="glimlacht terug"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Smiles back"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="glimlacht terug"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Speelt geven en nemen"/>
+            </extension>
+            <code value="26281000146106"/>
+            <display value="in staat om te geven en nemen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to give and take"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om te geven en nemen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan spelen met andere kinderen"/>
+            </extension>
+            <code value="26301000146107"/>
+            <display value="in staat om te spelen met andere kinderen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to play with other children"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om te spelen met andere kinderen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan vrienden maken"/>
+            </extension>
+            <code value="26291000146108"/>
+            <display value="in staat om vrienden te maken"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to make friends"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om vrienden te maken"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan zich inleven in anderen"/>
+            </extension>
+            <code value="26321000146104"/>
+            <display value="in staat om zich in te leven in anderen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to show empathy"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om zich in te leven in anderen"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/OntwikkelingTaalCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5--20200901000000.xml
+++ b/resources/zib/terminology/OntwikkelingTaalCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5--20200901000000.xml
@@ -1,167 +1,168 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="OntwikkelingTaalCodelijst"/>
-    <title value="OntwikkelingTaalCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="OntwikkelingTaalCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Brabbelt"/>
-                </extension>
-                <code value="258116008"/>
-                <display value="brabbelt"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Speech babble"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="brabbelt"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Begrijpt korte dagelijks gebruikte zinnen"/>
-                </extension>
-                <code value="26261000146103"/>
-                <display value="in staat om korte dagelijks gebruikte zinnen te begrijpen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to comprehend short daily used sentences"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om korte dagelijks gebruikte zinnen te begrijpen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Spreekt korte dagelijks gebruikte zinnen"/>
-                </extension>
-                <code value="26341000146105"/>
-                <display value="in staat om korte dagelijks gebruikte zinnen te spreken"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to speak short daily used sentences"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om korte dagelijks gebruikte zinnen te spreken"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Is verstaanbaar voor bekenden"/>
-                </extension>
-                <code value="26361000146106"/>
-                <display value="spreekt begrijpelijk voor kennissen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Speaks intelligibly for acquaintances"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="spreekt begrijpelijk voor kennissen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Is verstaanbaar voor onbekenden"/>
-                </extension>
-                <code value="26371000146100"/>
-                <display value="spreekt begrijpelijk voor vreemden"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Speaks intelligibly for strangers"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="spreekt begrijpelijk voor vreemden"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.5"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="OntwikkelingTaalCodelijst"/>
+   <title value="OntwikkelingTaalCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="OntwikkelingTaalCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Brabbelt"/>
+            </extension>
+            <code value="258116008"/>
+            <display value="brabbelt"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Speech babble"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="brabbelt"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Begrijpt korte dagelijks gebruikte zinnen"/>
+            </extension>
+            <code value="26261000146103"/>
+            <display value="in staat om korte dagelijks gebruikte zinnen te begrijpen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to comprehend short daily used sentences"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om korte dagelijks gebruikte zinnen te begrijpen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Spreekt korte dagelijks gebruikte zinnen"/>
+            </extension>
+            <code value="26341000146105"/>
+            <display value="in staat om korte dagelijks gebruikte zinnen te spreken"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to speak short daily used sentences"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om korte dagelijks gebruikte zinnen te spreken"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Is verstaanbaar voor bekenden"/>
+            </extension>
+            <code value="26361000146106"/>
+            <display value="spreekt begrijpelijk voor kennissen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Speaks intelligibly for acquaintances"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="spreekt begrijpelijk voor kennissen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Is verstaanbaar voor onbekenden"/>
+            </extension>
+            <code value="26371000146100"/>
+            <display value="spreekt begrijpelijk voor vreemden"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Speaks intelligibly for strangers"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="spreekt begrijpelijk voor vreemden"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/OntwikkelingVerstandelijkCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6--20200901000000.xml
+++ b/resources/zib/terminology/OntwikkelingVerstandelijkCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6--20200901000000.xml
@@ -1,167 +1,168 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="OntwikkelingVerstandelijkCodelijst"/>
-    <title value="OntwikkelingVerstandelijkCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="OntwikkelingVerstandelijkCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan abstract denken"/>
-                </extension>
-                <code value="281136009"/>
-                <display value="in staat om abstract te denken"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to think abstractly"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om abstract te denken"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan zelf problemen oplossen"/>
-                </extension>
-                <code value="716433009"/>
-                <display value="in staat om probleem op te lossen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to problem solve"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om probleem op te lossen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Heeft brede interesse"/>
-                </extension>
-                <code value="26381000146103"/>
-                <display value="brede interesse"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Wide level of interest"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="brede interesse"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Heeft inzicht in gevolgen van eigen gedrag"/>
-                </extension>
-                <code value="26311000146109"/>
-                <display value="in staat om gevolgen van eigen gedrag te herkennen"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to recognize consequences of behaviour"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om gevolgen van eigen gedrag te herkennen"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Kan beredeneerde keuzes maken"/>
-                </extension>
-                <code value="304687006"/>
-                <display value="in staat om beredeneerde keuzes te maken"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Able to make considered choices"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="in staat om beredeneerde keuzes te maken"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.6"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="OntwikkelingVerstandelijkCodelijst"/>
+   <title value="OntwikkelingVerstandelijkCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="OntwikkelingVerstandelijkCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan abstract denken"/>
+            </extension>
+            <code value="281136009"/>
+            <display value="in staat om abstract te denken"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to think abstractly"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om abstract te denken"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan zelf problemen oplossen"/>
+            </extension>
+            <code value="716433009"/>
+            <display value="in staat om probleem op te lossen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to problem solve"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om probleem op te lossen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Heeft brede interesse"/>
+            </extension>
+            <code value="26381000146103"/>
+            <display value="brede interesse"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Wide level of interest"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="brede interesse"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Heeft inzicht in gevolgen van eigen gedrag"/>
+            </extension>
+            <code value="26311000146109"/>
+            <display value="in staat om gevolgen van eigen gedrag te herkennen"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to recognize consequences of behaviour"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om gevolgen van eigen gedrag te herkennen"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Kan beredeneerde keuzes maken"/>
+            </extension>
+            <code value="304687006"/>
+            <display value="in staat om beredeneerde keuzes te maken"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Able to make considered choices"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="in staat om beredeneerde keuzes te maken"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/PolsRegelmatigheidCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1--20200901000000.xml
+++ b/resources/zib/terminology/PolsRegelmatigheidCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1--20200901000000.xml
@@ -1,93 +1,93 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
       <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+02:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="PolsRegelmatigheidCodelijst"/>
-    <title value="PolsRegelmatigheidCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="PolsRegelmatigheidCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Polsslag regelmatig"/>
-                </extension>
-                <code value="271636001"/>
-                <display value="regelmatige pulsaties"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Pulse regular"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="regelmatige pulsaties"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Polsslag onregelmatig"/>
-                </extension>
-                <code value="61086009"/>
-                <display value="onregelmatige pulsaties"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Pulse irregular"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="onregelmatige pulsaties"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.7.1"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="PolsRegelmatigheidCodelijst"/>
+   <title value="PolsRegelmatigheidCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="PolsRegelmatigheidCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Polsslag regelmatig"/>
+            </extension>
+            <code value="271636001"/>
+            <display value="regelmatige pulsaties"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Pulse regular"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="regelmatige pulsaties"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Polsslag onregelmatig"/>
+            </extension>
+            <code value="61086009"/>
+            <display value="onregelmatige pulsaties"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Pulse irregular"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="onregelmatige pulsaties"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/ReflexenScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5--20200901000000.xml
+++ b/resources/zib/terminology/ReflexenScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5--20200901000000.xml
@@ -1,71 +1,72 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+02:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="ReflexenScoreCodelijst"/>
-    <title value="ReflexenScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="ReflexenScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="http://loinc.org"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Reageert niet op prikkels/Geen reactie"/>
-                </extension>
-                <code value="LA6719-4"/>
-                <display value="No response to airways being suctioned"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Reageert met kleine jammergeluidjes en zwakke bewegingen"/>
-                </extension>
-                <code value="LA6720-2"/>
-                <display value="Grimace during suctioning"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="2"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Reageert door te huilen, te hoesten of te niezen"/>
-                </extension>
-                <code value="LA6721-0"/>
-                <display value="Grimace and pulling away, cough, or sneeze during suctioning"/>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.5"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="ReflexenScoreCodelijst"/>
+   <title value="ReflexenScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="ReflexenScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="http://loinc.org"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Reageert niet op prikkels/Geen reactie"/>
+            </extension>
+            <code value="LA6719-4"/>
+            <display value="No response to airways being suctioned"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Reageert met kleine jammergeluidjes en zwakke bewegingen"/>
+            </extension>
+            <code value="LA6720-2"/>
+            <display value="Grimace during suctioning"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="2"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Reageert door te huilen, te hoesten of te niezen"/>
+            </extension>
+            <code value="LA6721-0"/>
+            <display value="Grimace and pulling away, cough, or sneeze during suctioning"/>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/RefractieMeetMethodeCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.20.1--20200901000000.xml
+++ b/resources/zib/terminology/RefractieMeetMethodeCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.20.1--20200901000000.xml
@@ -43,7 +43,7 @@
                <valueString value="Subjectieve refractie"/>
             </extension>
             <code value="397277005"/>
-                <display value="Subjective refraction (procedure)"/>
+            <display value="subjectieve refractiemeting"/>
             <designation>
                <language value="en-US"/>
                <use>
@@ -68,7 +68,7 @@
                <valueString value="Objectieve refractie"/>
             </extension>
             <code value="397276001"/>
-                <display value="Objective refraction (procedure)"/>
+            <display value="objectieve refractiemeting"/>
             <designation>
                <language value="en-US"/>
                <use>

--- a/resources/zib/terminology/SKGewichtsverliesScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1--20200901000000.xml
+++ b/resources/zib/terminology/SKGewichtsverliesScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1--20200901000000.xml
@@ -1,79 +1,80 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="SKGewichtsverliesScoreCodelijst"/>
-    <title value="SKGewichtsverliesScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="SKGewichtsverliesScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.1"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Geen gewichtsverlies of stilstand in groei/ gewicht"/>
-                </extension>
-                <code value="G0"/>
-                <display value="NoLoss"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="NoLoss"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Gewichtsverlies of stilstand in groei/ gewicht aanwezig"/>
-                </extension>
-                <code value="G2"/>
-                <display value="LossOfWeight"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="LossOfWeight"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.1"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="SKGewichtsverliesScoreCodelijst"/>
+   <title value="SKGewichtsverliesScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="SKGewichtsverliesScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.1"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Geen gewichtsverlies of stilstand in groei/ gewicht"/>
+            </extension>
+            <code value="G0"/>
+            <display value="NoLoss"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="NoLoss"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Gewichtsverlies of stilstand in groei/ gewicht aanwezig"/>
+            </extension>
+            <code value="G2"/>
+            <display value="LossOfWeight"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="LossOfWeight"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/SKVoedingsScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3--20200901000000.xml
+++ b/resources/zib/terminology/SKVoedingsScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3--20200901000000.xml
@@ -1,79 +1,80 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="SKVoedingsScoreCodelijst"/>
-    <title value="SKVoedingsScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="SKVoedingsScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.3"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Normale voedselinname"/>
-                </extension>
-                <code value="Z0"/>
-                <display value="Normaal"/>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Normaal"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Verminderde voedselinname"/>
-                </extension>
-                <code value="Z1"/>
-                <display value="Verminderd"/>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Verminderd"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.3"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="SKVoedingsScoreCodelijst"/>
+   <title value="SKVoedingsScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="SKVoedingsScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.3"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Normale voedselinname"/>
+            </extension>
+            <code value="Z0"/>
+            <display value="Normaal"/>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Normaal"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Verminderde voedselinname"/>
+            </extension>
+            <code value="Z1"/>
+            <display value="Verminderd"/>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Verminderd"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/SKVoedingstoestandCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4--20200901000000.xml
+++ b/resources/zib/terminology/SKVoedingstoestandCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4--20200901000000.xml
@@ -1,79 +1,80 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="SKVoedingstoestandCodelijst"/>
-    <title value="SKVoedingstoestandCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="SKVoedingstoestandCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.4"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Goede voedingstoestand"/>
-                </extension>
-                <code value="T0"/>
-                <display value="Goed"/>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Goed"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Slechte voedingstoestand"/>
-                </extension>
-                <code value="T1"/>
-                <display value="Slecht"/>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Slecht"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.4"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="SKVoedingstoestandCodelijst"/>
+   <title value="SKVoedingstoestandCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="SKVoedingstoestandCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.4"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Goede voedingstoestand"/>
+            </extension>
+            <code value="T0"/>
+            <display value="Goed"/>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Goed"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Slechte voedingstoestand"/>
+            </extension>
+            <code value="T1"/>
+            <display value="Slecht"/>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Slecht"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/SKZiektebeeldScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2--20200901000000.xml
+++ b/resources/zib/terminology/SKZiektebeeldScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2--20200901000000.xml
@@ -1,79 +1,80 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="SKZiektebeeldScoreCodelijst"/>
-    <title value="SKZiektebeeldScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="SKZiektebeeldScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.2"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Geen ziektebeeld met verhoogd risico"/>
-                </extension>
-                <code value="R0"/>
-                <display value="NoRisk"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="NoRisk"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="2"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Ziektebeeld met verhoogd risico aanwezig"/>
-                </extension>
-                <code value="R1"/>
-                <display value="IncreasedRisk"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="IncreasedRisk"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.28.2"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="SKZiektebeeldScoreCodelijst"/>
+   <title value="SKZiektebeeldScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="SKZiektebeeldScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.17.2"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Geen ziektebeeld met verhoogd risico"/>
+            </extension>
+            <code value="R0"/>
+            <display value="NoRisk"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="NoRisk"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="2"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Ziektebeeld met verhoogd risico aanwezig"/>
+            </extension>
+            <code value="R1"/>
+            <display value="IncreasedRisk"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="IncreasedRisk"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/SoortAandoeningCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20200901000000.xml
+++ b/resources/zib/terminology/SoortAandoeningCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20200901000000.xml
@@ -1,151 +1,152 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="SoortAandoeningCodelijst"/>
-    <title value="SoortAandoeningCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="SoortAandoeningCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
-            <concept>
-                <code value="OTH"/>
-                <display value="Other"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Other"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Anders"/>
-                </designation>
-            </concept>
-        </include>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Huidletsel door incontinentie"/>
-                </extension>
-                <code value="402276007"/>
-                <display value="irritatief contacteczeem door incontinentie"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Irritant contact dermatitis due to incontinence"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="irritatief contacteczeem door incontinentie"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Intertrigo/smetten"/>
-                </extension>
-                <code value="58759008"/>
-                <display value="intertrigo"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Intertrigo"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="smetplek"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="intertrigo"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Eczeem"/>
-                </extension>
-                <code value="43116000"/>
-                <display value="eczeem"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Eczema"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="eczeem"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.19.3.1"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="SoortAandoeningCodelijst"/>
+   <title value="SoortAandoeningCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="SoortAandoeningCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor"/>
+         <concept>
+            <code value="OTH"/>
+            <display value="Other"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Other"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Anders"/>
+            </designation>
+         </concept>
+      </include>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Huidletsel door incontinentie"/>
+            </extension>
+            <code value="402276007"/>
+            <display value="irritatief contacteczeem door incontinentie"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Irritant contact dermatitis due to incontinence"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="irritatief contacteczeem door incontinentie"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Intertrigo/smetten"/>
+            </extension>
+            <code value="58759008"/>
+            <display value="intertrigo"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Intertrigo"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="smetplek"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="intertrigo"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Eczeem"/>
+            </extension>
+            <code value="43116000"/>
+            <display value="eczeem"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Eczema"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="eczeem"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/SpierspanningScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3--20200901000000.xml
+++ b/resources/zib/terminology/SpierspanningScoreCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3--20200901000000.xml
@@ -1,71 +1,72 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+02:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="SpierspanningScoreCodelijst"/>
-    <title value="SpierspanningScoreCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="SpierspanningScoreCodelijst"/>
-    <immutable value="false"/>
-    <compose>
-        <include>
-            <system value="http://loinc.org"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="0"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Geen spierspanning aanwezig/slap"/>
-                </extension>
-                <code value="LA6713-7"/>
-                <display value="Limp; no movement"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="1"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Weinig bewegingen met armpjes en beentjes"/>
-                </extension>
-                <code value="LA6714-5"/>
-                <display value="Some flexion of arms and legs"/>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
-                    <valueDecimal value="2"/>
-                </extension>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Beweegt armpjes en beentjes goed"/>
-                </extension>
-                <code value="LA6715-2"/>
-                <display value="Active motion"/>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.12.16.3"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="SpierspanningScoreCodelijst"/>
+   <title value="SpierspanningScoreCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="SpierspanningScoreCodelijst"/>
+   <immutable value="false"/>
+   <compose>
+      <include>
+         <system value="http://loinc.org"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="0"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Geen spierspanning aanwezig/slap"/>
+            </extension>
+            <code value="LA6713-7"/>
+            <display value="Limp; no movement"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="1"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Weinig bewegingen met armpjes en beentjes"/>
+            </extension>
+            <code value="LA6714-5"/>
+            <display value="Some flexion of arms and legs"/>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+               <valueDecimal value="2"/>
+            </extension>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Beweegt armpjes en beentjes goed"/>
+            </extension>
+            <code value="LA6715-2"/>
+            <display value="Active motion"/>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/ZindelijkheidFecesCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2--20200901000000.xml
+++ b/resources/zib/terminology/ZindelijkheidFecesCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2--20200901000000.xml
@@ -1,117 +1,118 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="ZindelijkheidFecesCodelijst"/>
-    <title value="ZindelijkheidFecesCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="ZindelijkheidFecesCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Niet zindelijk"/>
-                </extension>
-                <code value="26421000146106"/>
-                <display value="geen controle over defecatie op kinderleeftijd"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="No control of bowel - child"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="geen controle over defecatie op kinderleeftijd"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Af en toe een ongelukje"/>
-                </extension>
-                <code value="26441000146100"/>
-                <display value="incidenteel ontlastingsverlies op kinderleeftijd"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Occasional bowel accident - child"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="incidenteel ontlastingsverlies op kinderleeftijd"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Volledig zindelijk"/>
-                </extension>
-                <code value="26401000146103"/>
-                <display value="volledige controle over defecatie op kinderleeftijd"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Full control of bowel - child"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="volledige controle over defecatie op kinderleeftijd"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.2"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="ZindelijkheidFecesCodelijst"/>
+   <title value="ZindelijkheidFecesCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="ZindelijkheidFecesCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Niet zindelijk"/>
+            </extension>
+            <code value="26421000146106"/>
+            <display value="geen controle over defecatie op kinderleeftijd"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="No control of bowel - child"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="geen controle over defecatie op kinderleeftijd"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Af en toe een ongelukje"/>
+            </extension>
+            <code value="26441000146100"/>
+            <display value="incidenteel ontlastingsverlies op kinderleeftijd"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Occasional bowel accident - child"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="incidenteel ontlastingsverlies op kinderleeftijd"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Volledig zindelijk"/>
+            </extension>
+            <code value="26401000146103"/>
+            <display value="volledige controle over defecatie op kinderleeftijd"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Full control of bowel - child"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="volledige controle over defecatie op kinderleeftijd"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/ZindelijkheidUrineCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1--20200901000000.xml
+++ b/resources/zib/terminology/ZindelijkheidUrineCodelijst-2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1--20200901000000.xml
@@ -1,142 +1,143 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1--20200901000000"/>
-    <meta>
-        <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/><!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
-    </meta>
-    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
-        <valuePeriod>
-            <start value="2020-09-01T00:00:00+01:00"/>
-        </valuePeriod>
-    </extension>
-    <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1--20200901000000"/>
-    <identifier>
-        <use value="official"/>
-        <system value="urn:ietf:rfc:3986"/>
-        <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1"/>
-    </identifier>
-    <version value="2020-09-01T00:00:00"/>
-    <name value="ZindelijkheidUrineCodelijst"/>
-    <title value="ZindelijkheidUrineCodelijst"/>
-    <status value="active"/>
-    <experimental value="false"/>
-    <publisher value="Registratie aan de bron"/>
-    <contact>
-        <name value="Registratie aan de bron"/>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.registratieaandebron.nl"/>
-        </telecom>
-        <telecom>
-            <system value="url"/>
-            <value value="https://www.zibs.nl"/>
-        </telecom>
-    </contact>
-    <description value="ZindelijkheidUrineCodelijst"/>
-    <immutable value="false"/>
-    <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
-    <compose>
-        <include>
-            <system value="http://snomed.info/sct"/>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Niet zindelijk"/>
-                </extension>
-                <code value="26411000146101"/>
-                <display value="geen blaascontrole op kinderleeftijd"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="No control of bladder - child"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="geen blaascontrole op kinderleeftijd"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Zindelijk overdag, ’s nacht niet"/>
-                </extension>
-                <code value="29261000146107"/>
-                <display value="volledige blaascontrole uitsluitend overdag"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Full control of bladder only in daytime"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="volledige blaascontrole uitsluitend overdag"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Af en toe een ongelukje"/>
-                </extension>
-                <code value="26431000146108"/>
-                <display value="incidenteel urineverlies op kinderleeftijd"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Occasional bladder accident - child"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="incidenteel urineverlies op kinderleeftijd"/>
-                </designation>
-            </concept>
-            <concept>
-                <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
-                    <valueString value="Volledig zindelijk"/>
-                </extension>
-                <code value="26391000146101"/>
-                <display value="volledige blaascontrole op kinderleeftijd"/>
-                <designation>
-                    <language value="en-US"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="Full control of bladder - child"/>
-                </designation>
-                <designation>
-                    <language value="nl-NL"/>
-                    <use>
-                        <system value="http://snomed.info/sct"/>
-                        <code value="900000000000013009"/>
-                        <display value="Synonym"/>
-                    </use>
-                    <value value="volledige blaascontrole op kinderleeftijd"/>
-                </designation>
-            </concept>
-        </include>
-    </compose>
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1--20200901000000"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/ValueSet"/>-->
+   </meta>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1--20200901000000"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2.4.32.1"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="ZindelijkheidUrineCodelijst"/>
+   <title value="ZindelijkheidUrineCodelijst"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="ZindelijkheidUrineCodelijst"/>
+   <immutable value="false"/>
+   <copyright value="This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyright of the International Health Terminology Standards Development Organisation (IHTSDO). Implementers of these artefacts must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/getsnomed-ct or info@snomed.org."/>
+   <compose>
+      <include>
+         <system value="http://snomed.info/sct"/>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Niet zindelijk"/>
+            </extension>
+            <code value="26411000146101"/>
+            <display value="geen blaascontrole op kinderleeftijd"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="No control of bladder - child"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="geen blaascontrole op kinderleeftijd"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Zindelijk overdag, ’s nacht niet"/>
+            </extension>
+            <code value="29261000146107"/>
+            <display value="volledige blaascontrole uitsluitend overdag"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Full control of bladder only in daytime"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="volledige blaascontrole uitsluitend overdag"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Af en toe een ongelukje"/>
+            </extension>
+            <code value="26431000146108"/>
+            <display value="incidenteel urineverlies op kinderleeftijd"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Occasional bladder accident - child"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="incidenteel urineverlies op kinderleeftijd"/>
+            </designation>
+         </concept>
+         <concept>
+            <extension url="http://hl7.org/fhir/StructureDefinition/valueset-concept-comments">
+               <valueString value="Volledig zindelijk"/>
+            </extension>
+            <code value="26391000146101"/>
+            <display value="volledige blaascontrole op kinderleeftijd"/>
+            <designation>
+               <language value="en-US"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="Full control of bladder - child"/>
+            </designation>
+            <designation>
+               <language value="nl-NL"/>
+               <use>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="900000000000013009"/>
+                  <display value="Synonym"/>
+               </use>
+               <value value="volledige blaascontrole op kinderleeftijd"/>
+            </designation>
+         </concept>
+      </include>
+   </compose>
 </ValueSet>

--- a/resources/zib/terminology/codesystem-FLACC_Troostbaar-2.16.840.1.113883.2.4.3.11.60.40.4.21.5.xml
+++ b/resources/zib/terminology/codesystem-FLACC_Troostbaar-2.16.840.1.113883.2.4.3.11.60.40.4.21.5.xml
@@ -1,0 +1,100 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.4.21.5"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/CodeSystem"/>-->
+   </meta>
+   <language value="nl-NL"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.21.5"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.21.5"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="FLACC_Troostbaar"/>
+   <title value="FLACC_Troostbaar"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="FLACC_Troostbaar"/>
+   <caseSensitive value="false"/>
+   <content value="complete"/>
+   <count value="3"/>
+   <property>
+      <code value="ordinal-value"/>
+      <uri value="http://hl7.org/fhir/StructureDefinition/ordinalValue"/>
+      <description value="A numeric value that allows the comparison (less than, greater than) or other numerical manipulation of a concept (e.g. Adding up components of a score). Scores are usually a whole number, but occasionally decimals are encountered in scores."/>
+      <type value="integer"/>
+   </property>
+   <property>
+      <code value="status"/>
+      <uri value="http://hl7.org/fhir/concept-properties"/>
+      <description value="A code that indicates the status of the concept. Values found in this version of the code system are: active"/>
+      <type value="code"/>
+   </property>
+   <concept>
+      <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+         <valueDecimal value="0"/>
+      </extension>
+      <code value="Cons0"/>
+      <display value="Content"/>
+      <definition value="Is tevreden, ontspannen"/>
+      <property>
+         <code value="ordinal-value"/>
+         <valueInteger value="0"/>
+      </property>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+         <valueDecimal value="1"/>
+      </extension>
+      <code value="Cons1"/>
+      <display value="Consolable, distractable"/>
+      <definition value="Is te troosten door af en toe aan te raken, te knuffelen of toe te spreken; laat zich afleiden"/>
+      <property>
+         <code value="ordinal-value"/>
+         <valueInteger value="1"/>
+      </property>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <extension url="http://hl7.org/fhir/StructureDefinition/ordinalValue">
+         <valueDecimal value="2"/>
+      </extension>
+      <code value="Cons2"/>
+      <display value="Difficult to console"/>
+      <definition value="Is moeilijk te troosten of op te beuren"/>
+      <property>
+         <code value="ordinal-value"/>
+         <valueInteger value="2"/>
+      </property>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+</CodeSystem>

--- a/resources/zib/terminology/codesystem-GGZ_Diagnoselijst-2.16.840.1.113883.3.3210.14.2.2.35.xml
+++ b/resources/zib/terminology/codesystem-GGZ_Diagnoselijst-2.16.840.1.113883.3.3210.14.2.2.35.xml
@@ -3,7 +3,7 @@
    <language value="en-US"/>
    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
       <valuePeriod>
-         <start value="2022-09-28T12:56:05+00:00"/>
+         <start value="2023-04-14T09:51:24+00:00"/>
       </valuePeriod>
    </extension>
    <url value="urn:oid:2.16.840.1.113883.3.3210.14.2.2.35"/>
@@ -12,7 +12,7 @@
       <system value="urn:ietf:rfc:3986"/>
       <value value="urn:oid:2.16.840.1.113883.3.3210.14.2.2.35"/>
    </identifier>
-   <version value="2022-09-28T12:56:05"/>
+   <version value="2023-04-14T09:51:24"/>
    <name value="GGZ_Diagnoselijst"/>
    <title value="GGZ Diagnoselijst"/>
    <status value="unknown"/>

--- a/resources/zib/terminology/codesystem-G_Standaard_Contra_Indicaties__Tabel_40_-2.16.840.1.113883.2.4.4.1.902.40.xml
+++ b/resources/zib/terminology/codesystem-G_Standaard_Contra_Indicaties__Tabel_40_-2.16.840.1.113883.2.4.4.1.902.40.xml
@@ -3,7 +3,7 @@
    <language value="en-US"/>
    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
       <valuePeriod>
-         <start value="2022-09-28T12:56:00+00:00"/>
+         <start value="2023-04-14T09:51:16+00:00"/>
       </valuePeriod>
    </extension>
    <url value="urn:oid:2.16.840.1.113883.2.4.4.1.902.40"/>
@@ -12,7 +12,7 @@
       <system value="urn:ietf:rfc:3986"/>
       <value value="urn:oid:2.16.840.1.113883.2.4.4.1.902.40"/>
    </identifier>
-   <version value="2022-09-28T12:56:00"/>
+   <version value="2023-04-14T09:51:16"/>
    <name value="G_Standaard_Contra_Indicaties__Tabel_40_"/>
    <title value="G-Standaard Contra Indicaties (Tabel 40)"/>
    <status value="unknown"/>

--- a/resources/zib/terminology/codesystem-G_standaard_Ongewenste_medicatiegroepen-2.16.840.1.113883.2.4.4.1.902.122.xml
+++ b/resources/zib/terminology/codesystem-G_standaard_Ongewenste_medicatiegroepen-2.16.840.1.113883.2.4.4.1.902.122.xml
@@ -3,7 +3,7 @@
    <language value="en-US"/>
    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
       <valuePeriod>
-         <start value="2022-09-28T12:56:08+00:00"/>
+         <start value="2023-04-14T09:51:29+00:00"/>
       </valuePeriod>
    </extension>
    <url value="urn:oid:2.16.840.1.113883.2.4.4.1.902.122"/>
@@ -12,7 +12,7 @@
       <system value="urn:ietf:rfc:3986"/>
       <value value="urn:oid:2.16.840.1.113883.2.4.4.1.902.122"/>
    </identifier>
-   <version value="2022-09-28T12:56:08"/>
+   <version value="2023-04-14T09:51:29"/>
    <name value="G_standaard_Ongewenste_medicatiegroepen"/>
    <title value="G-standaard Ongewenste medicatiegroepen"/>
    <status value="unknown"/>

--- a/resources/zib/terminology/codesystem-G_standaard_Stofnaamcode_i_c_m__toedieningsweg__SSK_-2.16.840.1.113883.2.4.4.1.725.xml
+++ b/resources/zib/terminology/codesystem-G_standaard_Stofnaamcode_i_c_m__toedieningsweg__SSK_-2.16.840.1.113883.2.4.4.1.725.xml
@@ -3,7 +3,7 @@
    <language value="en-US"/>
    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
       <valuePeriod>
-         <start value="2022-09-28T12:55:51+00:00"/>
+         <start value="2023-04-14T09:51:10+00:00"/>
       </valuePeriod>
    </extension>
    <url value="urn:oid:2.16.840.1.113883.2.4.4.1.725"/>
@@ -12,7 +12,7 @@
       <system value="urn:ietf:rfc:3986"/>
       <value value="urn:oid:2.16.840.1.113883.2.4.4.1.725"/>
    </identifier>
-   <version value="2022-09-28T12:55:51"/>
+   <version value="2023-04-14T09:51:10"/>
    <name value="G_standaard_Stofnaamcode_i_c_m__toedieningsweg__SSK_"/>
    <title value="G-standaard Stofnaamcode i.c.m. toedieningsweg (SSK)"/>
    <status value="unknown"/>

--- a/resources/zib/terminology/codesystem-NHGTabel20CodeOpleiding-2.16.840.1.113883.2.4.4.30.20.xml
+++ b/resources/zib/terminology/codesystem-NHGTabel20CodeOpleiding-2.16.840.1.113883.2.4.4.30.20.xml
@@ -3,7 +3,7 @@
    <language value="en-US"/>
    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
       <valuePeriod>
-         <start value="2022-10-17T12:42:43+00:00"/>
+         <start value="2023-04-14T09:51:26+00:00"/>
       </valuePeriod>
    </extension>
    <url value="urn:oid:2.16.840.1.113883.2.4.4.30.20"/>
@@ -12,7 +12,7 @@
       <system value="urn:ietf:rfc:3986"/>
       <value value="urn:oid:2.16.840.1.113883.2.4.4.30.20"/>
    </identifier>
-   <version value="2022-10-17T12:42:43"/>
+   <version value="2023-04-14T09:51:26"/>
    <name value="NHGTabel20CodeOpleiding"/>
    <title value="NHGTabel20CodeOpleiding"/>
    <status value="unknown"/>

--- a/resources/zib/terminology/codesystem-ScoreObservaties-2.16.840.1.113883.2.4.3.11.60.40.4.0.1.xml
+++ b/resources/zib/terminology/codesystem-ScoreObservaties-2.16.840.1.113883.2.4.3.11.60.40.4.0.1.xml
@@ -7,7 +7,7 @@
    <language value="nl-NL"/>
    <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
       <valuePeriod>
-         <start value="2022-06-10T00:00:00+00:00"/>
+         <start value="2023-03-06T00:00:00+00:00"/>
       </valuePeriod>
    </extension>
    <url value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
@@ -16,10 +16,10 @@
       <system value="urn:ietf:rfc:3986"/>
       <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.0.1"/>
    </identifier>
-   <version value="2022-06-10T00:00:00"/>
+   <version value="2023.01.0"/>
    <name value="ScoreObservaties"/>
    <title value="ScoreObservaties"/>
-   <status value="active"/>
+   <status value="draft"/>
    <experimental value="false"/>
    <publisher value="Registratie aan de bron"/>
    <contact>
@@ -33,14 +33,14 @@
          <value value="https://www.zibs.nl"/>
       </telecom>
    </contact>
-   <description value="This zib code system serves to define definition codes for elements in zibs that describe a score instrument. Changes: &#xD;&#xA;* Version 2022-06-10T00:00:00: Added codes for DOSScore&#xD;&#xA;&#xD;&#xA;"/>
+   <description value="This zib code system serves to define definition codes for elements in zibs that describe a score instrument. Changes: &#xD;&#xA;* Version 2023-03-06T00:00:00: Added codes for BarthelADLIndex (ZIB-1692)&#xD;&#xA;* Version 2022-06-10T00:00:00: Added codes for DOSScore&#xD;&#xA;&#xD;&#xA;"/>
    <caseSensitive value="false"/>
    <content value="complete"/>
-   <count value="53"/>
+   <count value="63"/>
    <property>
       <code value="status"/>
       <uri value="http://hl7.org/fhir/concept-properties"/>
-      <description value="A code that indicates the status of the concept. Values found in this version of the code system are: active"/>
+      <description value="A code that indicates the status of the concept. Values found in this version of the code system are: active, draft"/>
       <type value="code"/>
    </property>
    <property>
@@ -1107,6 +1107,206 @@
       <property>
          <code value="effectiveDate"/>
          <valueDateTime value="2020-09-01"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002010"/>
+      <display value="BarthelIndex AanUitkleden"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Dressing"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002012"/>
+      <display value="BarthelIndex BadenDouchen"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Bathing"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002003"/>
+      <display value="BarthelIndex Blaas"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Bladder"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002004"/>
+      <display value="BarthelIndex Darm"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Bowels"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002007"/>
+      <display value="BarthelIndex Eten"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Feeding"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002009"/>
+      <display value="BarthelIndex Mobiliteit"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Mobility"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002006"/>
+      <display value="BarthelIndex Toiletgebruik"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex ToiletUse"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002008"/>
+      <display value="BarthelIndex Transfers"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Transfers"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002011"/>
+      <display value="BarthelIndex TrappenLopen"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex ManagingStairs"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="4002005"/>
+      <display value="BarthelIndex UiterlijkeVerzorging"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="BarthelADLIndex Grooming"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="draft"/>
+      </property>
+      <property>
+         <code value="effectiveDate"/>
+         <valueDateTime value="2023-03-06"/>
       </property>
    </concept>
 </CodeSystem>

--- a/resources/zib/terminology/codesystem-Weescodes-2.16.840.1.113883.2.4.3.11.60.40.4.xml
+++ b/resources/zib/terminology/codesystem-Weescodes-2.16.840.1.113883.2.4.3.11.60.40.4.xml
@@ -1,0 +1,147 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+   <id value="2.16.840.1.113883.2.4.3.11.60.40.4"/>
+   <meta>
+      <profile value="http://hl7.org/fhir/StructureDefinition/shareablecodesystem"/>
+      <!--<profile value="http://hl7.org/fhir/4.0/StructureDefinition/CodeSystem"/>-->
+   </meta>
+   <language value="nl-NL"/>
+   <extension url="http://hl7.org/fhir/StructureDefinition/resource-effectivePeriod">
+      <valuePeriod>
+         <start value="2020-09-01T00:00:00+00:00"/>
+      </valuePeriod>
+   </extension>
+   <url value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4"/>
+   <identifier>
+      <use value="official"/>
+      <system value="urn:ietf:rfc:3986"/>
+      <value value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4"/>
+   </identifier>
+   <version value="2020-09-01T00:00:00"/>
+   <name value="Weescodes"/>
+   <title value="Weescodes"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <publisher value="Registratie aan de bron"/>
+   <contact>
+      <name value="Registratie aan de bron"/>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.registratieaandebron.nl"/>
+      </telecom>
+      <telecom>
+         <system value="url"/>
+         <value value="https://www.zibs.nl"/>
+      </telecom>
+   </contact>
+   <description value="Weescodes"/>
+   <caseSensitive value="false"/>
+   <content value="complete"/>
+   <count value="8"/>
+   <property>
+      <code value="status"/>
+      <uri value="http://hl7.org/fhir/concept-properties"/>
+      <description value="A code that indicates the status of the concept. Values found in this version of the code system are: active, deprecated"/>
+      <type value="code"/>
+   </property>
+   <property>
+      <code value="inactive"/>
+      <uri value="http://hl7.org/fhir/concept-properties"/>
+      <description value="The date at which a concept was deprecated. Concepts that are deprecated but not inactive can still be used, but their use is discouraged, and they should be expected to be made inactive in a future release. Property type is dateTime. Note that the status property may also be used to indicate that a concept is deprecated"/>
+      <type value="boolean"/>
+   </property>
+   <concept>
+      <code value="APNA"/>
+      <display value="Toediener niet aanwezig"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="Administration performer not available"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="FORGOT"/>
+      <display value="Vergeten toe te dienen"/>
+      <designation>
+         <language value="en-US"/>
+         <use>
+            <system value="http://snomed.info/sct"/>
+            <code value="900000000000013009"/>
+         </use>
+         <value value="Forgotten to administer"/>
+      </designation>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="GeenGeloof"/>
+      <display value="Geen geloof"/>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="Humanist"/>
+      <display value="Humanist"/>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="JA"/>
+      <display value="Ja"/>
+      <definition value="Behandeling is toegestaan en/of wenselijk."/>
+      <property>
+         <code value="status"/>
+         <valueCode value="deprecated"/>
+      </property>
+      <property>
+         <code value="inactive"/>
+         <valueBoolean value="true"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="JA_MAAR"/>
+      <display value="Ja, maar met beperkingen"/>
+      <definition value="Behandeling toegestaan en/of wenselijk maar met beperkingen die dan ook vermeld moeten worden"/>
+      <property>
+         <code value="status"/>
+         <valueCode value="deprecated"/>
+      </property>
+      <property>
+         <code value="inactive"/>
+         <valueBoolean value="true"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="Mormoon"/>
+      <display value="Mormoon"/>
+      <property>
+         <code value="status"/>
+         <valueCode value="active"/>
+      </property>
+   </concept>
+   <concept>
+      <code value="NEE"/>
+      <display value="Nee"/>
+      <definition value="Behandeling niet toegestaan en/of wenselijk"/>
+      <property>
+         <code value="status"/>
+         <valueCode value="deprecated"/>
+      </property>
+      <property>
+         <code value="inactive"/>
+         <valueBoolean value="true"/>
+      </property>
+   </concept>
+</CodeSystem>


### PR DESCRIPTION
Adds:
- CodeSystem Weescodes (https://zibs.nl/wiki/ZibCodeSystems#Codestelsel:_NL-CM-CS, used in https://zibs.nl/wiki/Levensovertuiging-v3.2(2020NL) )
- CodeSystem FLACC_Troostbaar (used in https://zibs.nl/wiki/FLACCpainScale-v1.1(2020EN)#ConsolabilityCodelist )
Should have been added in these branches, but did not happen 

Edits:
- English to Dutch SNOMED displays in Lateraliteit and RefractieMeetMethode ValueSets (seems harmless to me)
- CodeSystem ScoreObservaties to include Barthel codes (based on ZIB-ticket 1692). Barthel itself is not merged yet, but since the codesystem is used elsewhere it is updated here.

Indenting and time zone update in several ValueSets (harmless)